### PR TITLE
Fixes #181 Renames Invalid XML Files string

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,7 @@
                     {{current_stats.aggregated.invalidxml}}
                     </a>
                 </td>
-                <td>Invalid XML Files</td>
+                <td>Files where XML is not well-formed</td>
             </tr>
             <tr>
                 <td>

--- a/templates/publisher.html
+++ b/templates/publisher.html
@@ -26,7 +26,7 @@
                         <li><a href="#p_validation">Files Failing Validation</a>
                         {% endif %}
                         {% if 1 in publisher_inverted.invalidxml.values() %}
-                        <li><a href="#p_invalid">Invalid XML Files</a>
+                        <li><a href="#p_invalid">Files where XML is not well-formed</a>
                         {% endif %}
                         {% if 1 in publisher_inverted.nonstandardroots.values() %}
                         <li><a href="#p_nonstandardroots">Files with non-standard roots</a>
@@ -140,7 +140,7 @@
 
     <div class="row">
         {{boxes.box('Files failing validation', publisher_stats.validation.fail, '../publisher_imgs/'+publisher+'_validation.png', publisher+'/validation.json', '', '-publisher')}}
-        {{boxes.box('Invalid XML Files', publisher_stats.invalidxml, '../publisher_imgs/'+publisher+'_invalidxml.png', publisher+'/invalidxml.json', '', '-publisher')}}
+        {{boxes.box('Files where XML is not well-formed', publisher_stats.invalidxml, '../publisher_imgs/'+publisher+'_invalidxml.png', publisher+'/invalidxml.json', '', '-publisher')}}
     </div>
 
     <h2 id="h_dataquality">Data Quality</h2>
@@ -208,7 +208,7 @@
     <div class="panel panel-default" id="p_invalid">
     <div class="panel-heading">
         <a href="{{stats_url}}/current/inverted-file-publisher/{{publisher}}/invalidxml.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Invalid XML Files</h3>
+        <h3 class="panel-title">Files where XML is not well-formed</h3>
     </div>
     <table class="table table-striped">
         <thead>

--- a/templates/xml.html
+++ b/templates/xml.html
@@ -9,7 +9,7 @@
 {% block content %}
 
     <div class="row">
-      {{boxes.box('Invalid XML files', current_stats.aggregated.invalidxml, 'invalidxml.png', 'invalidxml.json',
+      {{boxes.box('Files where XML is not well-formed', current_stats.aggregated.invalidxml, 'invalidxml.png', 'invalidxml.json',
         description='Count of files where the XML that is not well-formed, over time. Note: this is different from <a href="validation.html">validation against the schema</a>.')}}
       {{boxes.box('Files with non-standard roots', current_stats.aggregated.nonstandardroots, 'nonstandardroots.png', 'nonstandardroots.json',
         description='Count of files with non-standard root, over time. Note: Files with non-standard roots are those where the root XML element is not <code>iati-activities</code> or <code>iati-organisation</code> as we would expect.</p>')}}
@@ -21,7 +21,7 @@
     <div class="panel panel-default">
     <div class="panel-heading">
         <a href="{{stats_url}}/current/inverted-file/invalidxml.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Invalid XML Files</h3>
+        <h3 class="panel-title">Files where XML is not well-formed</h3>
     </div>
     <table class="table table-striped">
         <thead>


### PR DESCRIPTION
Renames 'Invalid XML Files' to 'Files where XML is not well formed'
