### PR TITLE
Add number of large files to homepage

### DIFF
--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block lhs_column %}
 {{ super () }}
-    
+
 <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">
@@ -86,6 +86,12 @@
                     </a>
                 </td>
                 <td>Files with Nonstandard Roots</td>
+            </tr>
+            <tr>
+                <td>
+                    {{current_stats.aggregated.toolarge}}
+                </td>
+                <td>Files that are too large to be processed</td>
             </tr>
             <tr>
                 <td>


### PR DESCRIPTION
Outputting the number of large files to the Dashboard "Overview" section gives
the full picture for the number of files that have been found and processed by
code in the IATI-Stats repo.

Therefore, the global consistency tests can be modified so that the total
number of datasets in the Registry can be compared against the sum of Dashboard
activity files + organisation files + fails that failed to download + files
where XML is not well-formed + files with nonstandard roots + files that are
too large.

Code for the tests is here:
https://github.com/IATI/IATI-Website-Tests/blob/master/tests/test_global_consistency.py