### PR TITLE
Make the humanitarian narrative more consistent

### DIFF
--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -69,7 +69,7 @@
           <p>If the number of activities is greater than 0, then this is set at 100. Otherwise, this is set at 0.</p>
 
           <h5>Using Humanitarian Attribute?</h5>
-          <p>This is the percentage - proportion of the number of activities.</p>
+          <p>Use of <code>@humanitarian</code> - proportion of the number of activities.</p>
 
           <h5>Appeal or Emergency Details</h5>
           <p>Use of humanitarian-scope element, both <code>@type</code> and <code>@code</code> must be present - proportion of the number of activities.</p>


### PR DESCRIPTION
The explanation for “Using Humanitarian Attribute?” is confusing / just a placeholder. This makes it consistent with the “Clusters” one.