### PR TITLE
[#370] Remove references to Data Tickets across the Dashboard

### DIFF
--- a/data.py
+++ b/data.py
@@ -199,13 +199,6 @@ with open('./data/downloads/errors') as fp:
     for line in fp:
         if line != '.\n':
             current_stats['download_errors'].append(line.strip('\n').split(' ', 3))
-data_tickets = defaultdict(list)
-with open('./data/issues.csv') as fp:
-    # Skip BOM
-    fp.read(3)
-    reader = unicodecsv.DictReader(fp)
-    for issue in reader:
-        data_tickets[issue['data_provider_regisrty_id']].append(issue)
 
 def transform_codelist_mapping_keys(codelist_mapping):
     # Perform the same transformation as https://github.com/IATI/IATI-Stats/blob/d622f8e88af4d33b1161f906ec1b53c63f2f0936/stats.py#L12

--- a/fetch_data.sh
+++ b/fetch_data.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# Store list of current download errors and data.tickets issues
+# Store list of current download errors
 mkdir -p data/downloads/
 wget "https://gist.github.com/iati-bot/4f86dc7b36562c8b2b21/raw/errors" -O data/downloads/errors
-wget "http://data.tickets.iatistandard.org/query?status=accepted&status=assigned&status=new&status=reopened&format=csv&col=id&col=summary&col=status&col=owner&col=component&col=element&col=data_provider_regisrty_id&order=priority" -O data/issues.csv
 
 # Get CKAN (IATI Registry) data
 python fetch_data.py

--- a/make_csv.py
+++ b/make_csv.py
@@ -23,7 +23,6 @@ def publisher_dicts():
             'Reporting Org on Registry': data.ckan_publishers[publisher]['result']['publisher_iati_id'],
             'Reporting Orgs in Data (count)': len(publisher_stats['reporting_orgs']),
             'Reporting Orgs in Data': ';'.join(publisher_stats['reporting_orgs']),
-            'Data Tickets': len(data.data_tickets[publisher]),
             'Hierarchies (count)': len(publisher_stats['hierarchies']),
             'Hierarchies': ';'.join(publisher_stats['hierarchies']),
         }
@@ -41,7 +40,6 @@ with open(os.path.join('out', 'publishers.csv'), 'w') as fp:
         'Reporting Org on Registry',
         'Reporting Orgs in Data (count)',
         'Reporting Orgs in Data',
-        'Data Tickets',
         'Hierarchies (count)',
         'Hierarchies',
         ])

--- a/make_html.py
+++ b/make_html.py
@@ -102,7 +102,6 @@ app.jinja_env.globals['ckan'] = ckan
 app.jinja_env.globals['ckan_publishers'] = ckan_publishers
 app.jinja_env.globals['publisher_name'] = publisher_name
 app.jinja_env.globals['publishers_ordered_by_title'] = publishers_ordered_by_title
-app.jinja_env.globals['data_tickets'] = data_tickets
 app.jinja_env.globals['get_publisher_stats'] = get_publisher_stats
 app.jinja_env.globals['set'] = set
 app.jinja_env.globals['firstint'] = firstint

--- a/static/templates/faq.html
+++ b/static/templates/faq.html
@@ -43,11 +43,6 @@
 <p>With international timezones and large updates, it can sometimes take more than 24 hours before published data is used in the IATI Dashboard.</p>
 <p>Should you still believe that data is missing from the Dashboard, we’d love to hear from you - please contact us on support@iatistandard.org</p>
 
-<h3>What are the “data tickets” and how can I respond?</h3>
-<p>We set this system up as a public way to log and track issues on any dataset - so that data users do not discover the same things time and again.  </p>
-<p>To respond or create a ticket, just create an account at <a href="http://data.tickets.iatistandard.org/">Data Tickets</a></p>
-<p>When tickets are tagged with the relevant IATI Registry ID for the publisher, then these are pulled automatically into the publisher page.  Once a ticket has been marked as resolved, it is omitted from the Dashboard page on the next build.</p>
-
 
 <h3>I want to get to the raw data of a publisher - how can I do that?</h3>
 <p>Two ways:</p>

--- a/static/templates/publisher.html
+++ b/static/templates/publisher.html
@@ -19,9 +19,6 @@
                 <li><a href="#h_headlines">Headlines</a>
                 <li><a href="#h_dataquality">Data Quality</a>
                     <ul>
-                        {% if publisher in data_tickets and data_tickets[publisher]|count %}
-                        <li><a href="#p_datatickets">Data Tickets</a>
-                        {% endif %}
                         {% if publisher in current_stats.inverted_file_grouped.validation.fail %}
                         <li><a href="#p_validation">Files Failing Validation</a>
                         {% endif %}
@@ -148,25 +145,6 @@
     <p>This section will be blank if no issues were found.</p>
 
     <div class="row">
-    {% if publisher in data_tickets and data_tickets[publisher]|count %}
-    <div class="col-md-6">
-        <div class="panel panel-default" id="p_datatickets">
-          <div class="panel-heading"><h3 class="panel-title" id="list_fail_validation">Data Tickets</h3></div>
-
-          <table class="table">
-            {% for issue in data_tickets[publisher] %}
-            <tr>
-                <td><a href="http://data.tickets.iatistandard.org/ticket/{{issue.id}}">{{issue.status}}</a></td>
-                <td><a href="http://data.tickets.iatistandard.org/ticket/{{issue.id}}">{{issue.summary}}</a></td>
-                <td><a href="http://data.tickets.iatistandard.org/ticket/{{issue.id}}">{{issue.component}}</a></td>
-                <td><a href="http://data.tickets.iatistandard.org/ticket/{{issue.id}}">{{issue.element}}</a></td>
-                <td><a href="http://data.tickets.iatistandard.org/ticket/{{issue.id}}">{{issue.owner}}</a></td>
-            </tr>
-            {% endfor %}
-          </table>
-        </div>
-    </div>
-    {% endif %}
 
     {% if publisher in current_stats.inverted_file_grouped.validation.fail %}
     <div class="col-md-6">
@@ -433,4 +411,3 @@ $('.popover-html').popover({
 <script>$(function() { $("table.table:not(.exploring-data)").tablesorter(); });</script>
 <script>$(function() { $("table.exploring-data").tablesorter({textExtraction:{3: function(node,table,cellIndex) { return $(node).attr('data-bytes'); }}}); });</script>
 {% endblock %}
-

--- a/static/templates/publishers.html
+++ b/static/templates/publishers.html
@@ -26,7 +26,6 @@
                 <th>Total File Size <a href="{{stats_url}}/current/inverted-publisher/file_size.json">(J)</a></th>
                 <th>Hierarchies <a href="{{stats_url}}/current/inverted-publisher/hierarchies.json">(J)</a></th>
                 <th>Reporting Orgs <a href="{{stats_url}}/current/inverted-publisher/reporting_orgs.json">(J)</a></th>
-                <th>Data Tickets</th>
             </tr>
         </thead>
         <tbody>
@@ -41,13 +40,12 @@
                 <td data-bytes="{{current_stats.inverted_publisher.file_size.get(publisher)}}">{{current_stats.inverted_publisher.file_size.get(publisher)|filesizeformat}}</td>
                 <td>{{publisher_stats.hierarchies|length}}</td>
                 <td>{{publisher_stats.reporting_orgs|length}}</td>
-                <td>{{data_tickets[publisher]|count}}</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
     </div>
-    <p id="files_note">* Files is the sum of Activity Files <a href="{{stats_url}}/current/inverted-publisher/activity_files.json">(J)</a> and Organisation Files <a href="{{stats_url}}/current/inverted-publisher/organisation_files.json">(J)</a>.</p> 
+    <p id="files_note">* Files is the sum of Activity Files <a href="{{stats_url}}/current/inverted-publisher/activity_files.json">(J)</a> and Organisation Files <a href="{{stats_url}}/current/inverted-publisher/organisation_files.json">(J)</a>.</p>
 {% endblock %}
 {% block tablesorteroptions %}
 {textExtraction:{5: function(node,table,cellIndex) { return $(node).attr('data-bytes'); }}}


### PR DESCRIPTION
The data tickets service is being closed down as it is not used and
is a maintenance burden. This commit removes the interation between
the Dashboard and Data Tickets.