### PR TITLE
Cast humanitarian publisher stats denominators to float values

### DIFF
--- a/humanitarian.py
+++ b/humanitarian.py
@@ -37,24 +37,24 @@ def table():
 
         # Calculate percentage of all humanitarian activities that are defined using the @humanitarian attribute
         row['humanitarian_attrib'] = (
-            publisher_stats.get('humanitarian', {}).get('is_humanitarian_by_attrib', '0') / row['num_activities']
+            publisher_stats.get('humanitarian', {}).get('is_humanitarian_by_attrib', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
 
         # Calculate percentage of all humanitarian activities that use the <humanitarian-scope> element to define an appeal or emergency
         row['appeal_emergency'] = (
-            publisher_stats.get('humanitarian', {}).get('contains_humanitarian_scope', '0') / row['num_activities']
+            publisher_stats.get('humanitarian', {}).get('contains_humanitarian_scope', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
 
         # Calculate percentage of all humanitarian activities that use clusters
         row['clusters'] = (
-            publisher_stats.get('humanitarian', {}).get('uses_humanitarian_clusters_vocab', '0') / row['num_activities']
+            publisher_stats.get('humanitarian', {}).get('uses_humanitarian_clusters_vocab', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
 
         # Calculate the mean average
-        row['average'] = (row['publishing_humanitarian'] + row['humanitarian_attrib'] + row['appeal_emergency'] + row['clusters']) / 4
+        row['average'] = (row['publishing_humanitarian'] + row['humanitarian_attrib'] + row['appeal_emergency'] + row['clusters']) / float(4)
 
         # Return a generator object
         yield row


### PR DESCRIPTION
Resolves bug where more the number of activities using the `humanitarian-scope` element was incorrectly reported as 0%. This was due to integer vs. floating-point division.