### PR TITLE
Update humanitarian.html

### DIFF
--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -41,7 +41,7 @@
                 <tr {% if loop.last %} style="border-bottom: 1px solid gray;"{% endif %}>
                     <td style="border-right: 1px solid gray; border-left: 1px solid gray;"><a href="publisher/{{row.publisher}}.html">{{row.publisher_title}}</a></td>
                     {% for column_slug, _ in humanitarian.columns %}
-                    <td style="border-right: 1px solid gray; border-left: 1px solid gray;">{{row[column_slug]}}</th>
+                    <td style="border-right: 1px solid gray; border-left: 1px solid gray;">{{row[column_slug]|int}}</th>
                     {% endfor %}
                     </td>
                 </tr>


### PR DESCRIPTION
Cast values in columns to `int`.

This stops lots and lots and lots and lots and lots of decimal places showing.