### PR TITLE
Add rounding to humanitarian reporting page

### DIFF
--- a/humanitarian.py
+++ b/humanitarian.py
@@ -40,21 +40,25 @@ def table():
             publisher_stats.get('humanitarian', {}).get('is_humanitarian_by_attrib', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
+        row['humanitarian_attrib'] = round(row['humanitarian_attrib'], 2)
 
         # Calculate percentage of all humanitarian activities that use the <humanitarian-scope> element to define an appeal or emergency
         row['appeal_emergency'] = (
             publisher_stats.get('humanitarian', {}).get('contains_humanitarian_scope', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
+        row['appeal_emergency'] = round(row['appeal_emergency'], 2)
 
         # Calculate percentage of all humanitarian activities that use clusters
         row['clusters'] = (
             publisher_stats.get('humanitarian', {}).get('uses_humanitarian_clusters_vocab', '0') / float(row['num_activities'])
               if int(row['num_activities']) > 0 else 0
             ) * 100
+        row['clusters'] = round(row['clusters'], 2)
 
         # Calculate the mean average
         row['average'] = (row['publishing_humanitarian'] + row['humanitarian_attrib'] + row['appeal_emergency'] + row['clusters']) / float(4)
+        row['average'] = round(row['average'], 2)
 
         # Return a generator object
         yield row


### PR DESCRIPTION
This rounds the output of the `Using Humanitarian Attribute?`, `Appeal or Emergency Details`, `Clusters` and `Average` columns to two decimal places.

Replaces #457 and stops lots and lots and lots and lots and lots of decimal places showing.