### PR TITLE
Fixes typo

### DIFF
--- a/static/templates/forwardlooking.html
+++ b/static/templates/forwardlooking.html
@@ -32,7 +32,7 @@
             </p>
 
             <p>
-                Activities are excluded from forward looking calculations if they contain commitment transactions and 90% of the total commitment value has already been disbursed or expended in the corrsponding year or previously.  Additionally, activities are excluded if they have less than six months left to run.
+                Activities are excluded from forward looking calculations if they contain commitment transactions and 90% of the total commitment value has already been disbursed or expended in the corresponding year or previously.  Additionally, activities are excluded if they have less than six months left to run.
             </p>
 
             <p><strong>Key:</strong><br/>
@@ -94,7 +94,7 @@
         <li>Counting the number of activities that contain budgets provides a fairer result than summing the value of these budgets. The proportion of a publisher's total commitment for a future year that has already been committed to existing projects may vary greatly (e.g. you may have earmarked an amount to spend in three-years’ time, but not yet agreed on how to spend it.)</li>
         <li>For publisher's reporting multiple hierarchical levels ONLY the level that budgets are reported at is used in this calculation. However if budgets are reported at multiple levels, all activities are counted, and the publisher is marked with a red flag.</li>
         </ul>
-        <p>As noted above, activities are excluded from forward looking calculations if they contain commitment transactions and 90% of the total commitment value has already been disbursed or expended in the corrsponding year or previously. Additionally, activities are excluded if they have less than six months left to run (based on the reported actual or planned end date).</p>
+        <p>As noted above, activities are excluded from forward looking calculations if they contain commitment transactions and 90% of the total commitment value has already been disbursed or expended in the corresponding year or previously. Additionally, activities are excluded if they have less than six months left to run (based on the reported actual or planned end date).</p>
     </div>
     </div>
 


### PR DESCRIPTION
The word "corresponding" was written as "corrsponding", twice