### PR TITLE
Update comprehensiveness_financials text

### DIFF
--- a/static/templates/comprehensiveness_financials.html
+++ b/static/templates/comprehensiveness_financials.html
@@ -25,7 +25,7 @@ Table of Financial values
 	<p>For the data in the chosen hierarchy, the percentage of all current activities that contain at least one transaction of type <code>Commitment</code> or <code>Incoming Commitment</code>.  The hierarchy chosen for this calculation is the highest hierarchy that contains an above-defined commitment tranaction. Only one hierarchy is selected due in line with <a href="http://support.iatistandard.org/entries/40759343-General-rules-for-multi-level-reporting">stated IATI rules on multi-level reporting</a>.
 
 	<h5>Transaction - Disbursement or Expenditure</h5>
-	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities that contain at least one transaction of type <code>Disbursement</code> or <code>Expenditure</code>. (NB activities less than one year old are excluded from the calculation as it is fair to assume that disbursements are not always made in the early stages of an activity's development)</p>
+	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities that contain at least one transaction of type <code>Disbursement</code> or <code>Expenditure</code>.</p>
 
 
 	<h5>Transaction - Traceability</h5>

--- a/static/templates/comprehensiveness_financials.html
+++ b/static/templates/comprehensiveness_financials.html
@@ -25,7 +25,7 @@ Table of Financial values
 	<p>For the data in the chosen hierarchy, the percentage of all current activities that contain at least one transaction of type <code>Commitment</code> or <code>Incoming Commitment</code>.  The hierarchy chosen for this calculation is the highest hierarchy that contains an above-defined commitment tranaction. Only one hierarchy is selected due in line with <a href="http://support.iatistandard.org/entries/40759343-General-rules-for-multi-level-reporting">stated IATI rules on multi-level reporting</a>.
 
 	<h5>Transaction - Disbursement or Expenditure</h5>
-	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities with a start date more than one year ago that contain at least one transaction of type <code>Disbursement</code> or <code>Expenditure</code>. (NB activities less than one year old are excluded from the calculation as it is fair to assume that disbursements are not always made in the early stages of an activity's development)</p>
+	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities that contain at least one transaction of type <code>Disbursement</code> or <code>Expenditure</code>. (NB activities less than one year old are excluded from the calculation as it is fair to assume that disbursements are not always made in the early stages of an activity's development)</p>
 
 
 	<h5>Transaction - Traceability</h5>


### PR DESCRIPTION
The current text wrongly states that only current activities with a start date more than one year ago will be counted. See current methodology in [here](https://github.com/IATI/IATI-Stats/blob/master/stats/dashboard.py#L1024).

The change was made by mistake in [here](https://github.com/IATI/IATI-Dashboard/commit/1208b3e4662b857ad3755a780440b80f354c4c14) and I am now suggesting this amendment.