### PR TITLE
Update traceability descriptions (relates to v2.02 and v2.03 upgrades)

### DIFF
--- a/static/templates/comprehensiveness_base.html
+++ b/static/templates/comprehensiveness_base.html
@@ -199,7 +199,7 @@ If the activity is current
                 Else
                     Ignore activity
             Else If the comprehensiveness test is 'Transaction - Traceability'
-                If transaction/transaction-type[@code="IF"] exists (1.xx) or transaction/transaction-type[@code="1"] exists (2.xx)
+                If transaction/transaction-type[@code="IF"] exists (1.xx) or transaction/transaction-type[@code="1"] exists (2.xx) or transaction/transaction-type[@code="11"] exists or transaction/transaction-type[@code="13"] exists
                     Use activity
                 Else
                     Ignore activity
@@ -309,7 +309,7 @@ Else
       <tr>
         <td>Financials</td>
         <td>Transaction - Traceability</td>
-        <td>All transactions of @type=IF (1.xx) or @type=1 (2.xx) must contain provider-org/@provider-activity-id</td>
+        <td>All transactions with @type of 'Incoming Funds' (i.e. `IF` (1.xx) or `1` (2.xx)) or 'Incoming Commitment' (i.e. `11`) or 'Incoming Pledge' (i.e. `13`) must contain provider-org/@provider-activity-id</td>
         <td></td>
       </tr>
       <tr>

--- a/static/templates/comprehensiveness_financials.html
+++ b/static/templates/comprehensiveness_financials.html
@@ -29,7 +29,7 @@ Table of Financial values
 
 
 	<h5>Transaction - Traceability</h5>
-	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities containing a transaction of type <code>Incoming Funds</code> that also contain the IATI identifier for the funding organisation's activity. This links the funds disbursed by one organisation and received by another. (NB activities that do not contain incoming funds transactions are excluded from the calculation.) (In future the syntax of the provider-activity-id will also be validated.)</p>
+	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities containing a transaction of type <code>Incoming Funds</code>, <code>Incoming Commitment</code> or <code>Incoming Pledge</code> that also contain the IATI identifier for the funding organisation's activity. This links the funds disbursed by one organisation and received by another. (NB activities that do not contain incoming funds transactions are excluded from the calculation.) (In future the syntax of the provider-activity-id will also be validated.)</p>
 
 	<p>Donor publishers who list themselves within as a participating-org of either <code>1</code> (i.e. 'Funding') or <code>3</code> (i.e. 'Extending') AND who are not listed as type <code>4</code> (i.e. 'Implementing') will be given credit for traceability, as they are at the top of the funding chain.</p>
 


### PR DESCRIPTION
…According to IATI/IATI-Stats@4b4582fa. Refs #468.

Here’s the updated text:

> ### Transaction - Traceability
> 
> For the data at the publishers' lowest hierarchy, the percentage of current activities containing a transaction of type `Incoming Funds`, `Incoming Commitment` or `Incoming Pledge` that also contain the IATI identifier for the funding organisation's activity. This links the funds disbursed by one organisation and received by another. (NB activities that do not contain incoming funds transactions are excluded from the calculation.) (In future the syntax of the provider-activity-id will also be validated.)
