### PR TITLE
Cache JSONDir.__getitem__

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,10 +1,54 @@
 import json
 from collections import OrderedDict, defaultdict
+from functools import partial
 import sys, os, re, copy, datetime, unicodecsv
 import UserDict
 import csv
 
 publisher_re = re.compile('(.*)\-[^\-]')
+
+
+class memoize(object):
+    """From:
+    http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
+
+    cache the return value of a method
+
+    This class is meant to be used as a decorator of methods. The return value
+    from a given method invocation will be cached on the instance whose method
+    was invoked. All arguments passed to a method decorated with memoize must
+    be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method:
+    class Obj(object):
+        @memoize
+        def add_to(self, arg):
+            return self + arg
+    Obj.add_to(1) # not enough arguments
+    Obj.add_to(1, 2) # returns 3, result is not cached
+    """
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
+
 
 class GroupFiles(object, UserDict.DictMixin):
     def __init__(self, inputdict):
@@ -64,6 +108,7 @@ class JSONDir(object, UserDict.DictMixin):
         """
         self.folder = folder
 
+    @memoize
     def __getitem__(self, key):
         """Define how variables are gathered from the raw JSON files and then parsed into
            the OrderedDict that will be returned.

--- a/data.py
+++ b/data.py
@@ -1,6 +1,5 @@
 import json
 from collections import OrderedDict, defaultdict
-from functools import partial
 import sys, os, re, copy, datetime, unicodecsv
 import UserDict
 import csv
@@ -8,46 +7,16 @@ import csv
 publisher_re = re.compile('(.*)\-[^\-]')
 
 
-class memoize(object):
-    """From:
-    http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
-
-    cache the return value of a method
-
-    This class is meant to be used as a decorator of methods. The return value
-    from a given method invocation will be cached on the instance whose method
-    was invoked. All arguments passed to a method decorated with memoize must
-    be hashable.
-
-    If a memoized method is invoked directly on its class the result will not
-    be cached. Instead the method will be invoked like a static method:
-    class Obj(object):
-        @memoize
-        def add_to(self, arg):
-            return self + arg
-    Obj.add_to(1) # not enough arguments
-    Obj.add_to(1, 2) # returns 3, result is not cached
-    """
-    def __init__(self, func):
-        self.func = func
-
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self.func
-        return partial(self, obj)
-
-    def __call__(self, *args, **kw):
-        obj = args[0]
-        try:
-            cache = obj.__cache
-        except AttributeError:
-            cache = obj.__cache = {}
-        key = (self.func, args[1:], frozenset(kw.items()))
-        try:
-            res = cache[key]
-        except KeyError:
-            res = cache[key] = self.func(*args, **kw)
-        return res
+# Modified from:
+#   https://github.com/IATI/IATI-Stats/blob/1d20ed1e/stats/common/decorators.py#L5-L13
+def memoize(f):
+    def wrapper(self, key):
+        if not hasattr(self, '__cache'):
+            self.__cache = {}
+        if key not in self.__cache:
+            self.__cache[key] = f(self, key)
+        return self.__cache[key]
+    return wrapper
 
 
 class GroupFiles(object, UserDict.DictMixin):

--- a/data.py
+++ b/data.py
@@ -77,24 +77,6 @@ class GroupFiles(object, UserDict.DictMixin):
         self.cache[key] = out
         return out
 
-def JSONDir_to_memory(JSONDir_obj):
-    """Copies data from a JSONDir object to an in-memory OrderedDict.
-       Use sparingly due to the memory that copying publisher data consumes!
-    Input: JSONDir_obj - a JSONDir object
-    Returns: An in-memory OrderedDict
-    """
-
-    output_data = OrderedDict()
-
-    # Loop over data within the JSONDir_obj and add to output data
-    for publisher, agg in JSONDir_obj.items():
-        output_data_sub = OrderedDict()
-        for k,v in agg.items():
-           output_data_sub.update({k: v})
-        output_data.update({publisher: output_data_sub})
-
-    return output_data
-
 
 class JSONDir(object, UserDict.DictMixin):
     """Produces an object, to be used to access JSON-formatted publisher data and return

--- a/data.py
+++ b/data.py
@@ -10,7 +10,9 @@ publisher_re = re.compile('(.*)\-[^\-]')
 # Modified from:
 #   https://github.com/IATI/IATI-Stats/blob/1d20ed1e/stats/common/decorators.py#L5-L13
 def memoize(f):
-    def wrapper(self, key):
+    def wrapper(self, key, cache=False):
+        if not cache:
+            return f(self, key)
         if not hasattr(self, '__cache'):
             self.__cache = {}
         if key not in self.__cache:
@@ -60,7 +62,7 @@ class JSONDir(object, UserDict.DictMixin):
         self.folder = folder
 
     @memoize
-    def __getitem__(self, key):
+    def __getitem__(self, key, cache=False):
         """Define how variables are gathered from the raw JSON files and then parsed into
            the OrderedDict that will be returned.
 


### PR DESCRIPTION
Fixes #482:

> make_csv.py generates a bunch of CSVs fairly quickly, and then four comprehensiveness CSVs veeeery very slowly.
> 
> The problem is the same as for #481. Namely: `JSONDir`s are being treated as if they’re normal dicts, and they’re definitely not.
> 
> `JSONDir` defines a `__getitem__` method, so it behaves a bit like a dict. But instead of reading from memory, `JSONDir.__getitem__` loads and parses a JSON file from disk _every time it’s called_. This is super slow.
> 
> There are two solutions here. One is to use `JSONDir` very carefully. The other is to add some caching. It’s possible that caching could be quite expensive in terms of memory – I haven’t investigated. But I’d guess it’s probably fine.