### PR TITLE
Fix bug so that publisher type shows on the humanitarian dashboard

### DIFF
--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -66,7 +66,7 @@
         	<p>Only publishers with humanitarian activities included.</p>
 
           <h5>Publisher Type</h5>
-          <p>The category that this self-defines themselves as for their IATI Regsitry account.</p>
+          <p>The category that this publisher self-defines as on the IATI Registry.</p>
 
           <h5>Number of Activities</h5>
           <p>Total number of humanitarian activities (determined by use of <code>iati-activity/@humanitarian</code> attribute or <code>&lt;humanitarian-scope&gt;</code> element or DAC 5-digit sector codes between <code>72010</code> to <code>74010</code> inclusive, or DAC 3-digit sector codes <code>720</code>, <code>730</code> or <code>740</code>).</p>

--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -41,7 +41,13 @@
                 <tr {% if loop.last %} style="border-bottom: 1px solid gray;"{% endif %}>
                     <td style="border-right: 1px solid gray; border-left: 1px solid gray;"><a href="publisher/{{row.publisher}}.html">{{row.publisher_title}}</a></td>
                     {% for column_slug, _ in humanitarian.columns %}
-                    <td style="border-right: 1px solid gray; border-left: 1px solid gray;">{{row[column_slug]|int}}</td>
+                      <td style="border-right: 1px solid gray; border-left: 1px solid gray;">
+                        {%- if column_slug == 'publisher_type' -%}
+                          {{row[column_slug]}}
+                        {%- else -%}
+                          {{row[column_slug]|int}}
+                        {%- endif -%}
+                      </td>
                     {% endfor %}
                     </td>
                 </tr>

--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -41,7 +41,7 @@
                 <tr {% if loop.last %} style="border-bottom: 1px solid gray;"{% endif %}>
                     <td style="border-right: 1px solid gray; border-left: 1px solid gray;"><a href="publisher/{{row.publisher}}.html">{{row.publisher_title}}</a></td>
                     {% for column_slug, _ in humanitarian.columns %}
-                    <td style="border-right: 1px solid gray; border-left: 1px solid gray;">{{row[column_slug]|int}}</th>
+                    <td style="border-right: 1px solid gray; border-left: 1px solid gray;">{{row[column_slug]|int}}</td>
                     {% endfor %}
                     </td>
                 </tr>


### PR DESCRIPTION
Fixes #486:

> The Publisher Type column on the humanitarian dashboard is 0 for every publisher.
> 
> The definition says:
> 
> > #### Publisher Type
> >
> > The category that this self-defines themselves as for their IATI Regsitry account.
> 
> …so it’s unclear what this even refers to.
> 
> [Reading the code](https://github.com/IATI/IATI-Dashboard/blob/cf2c6350b54448c98e0daaa2290b20c1a2d2aaee/humanitarian.py#L32), it’s clear this refers to the [OrganisationType codelist](http://iatistandard.org/codelists/OrganisationType). And clicking “[(This table as CSV)](http://dashboard.iatistandard.org/humanitarian.csv)”, you can see that the CSV is correct. So the problem is with the HTML template.
> 
> In fact, it’s here:
> https://github.com/IATI/IATI-Dashboard/blob/cf2c6350b54448c98e0daaa2290b20c1a2d2aaee/static/templates/humanitarian.html#L44
> 
> Every cell value is cast to an int, which works fine for numeric cells, but not for Publisher Type.

Before:

Before | After
--------- | -------
![screen shot 2018-07-23 at 12 26 02](https://user-images.githubusercontent.com/464193/43074031-ad80504a-8e73-11e8-956f-5f0c9de0b542.png) | ![screen shot 2018-07-23 at 10 23 25](https://user-images.githubusercontent.com/464193/43068556-9d7151c4-8e62-11e8-9387-1afc6fd2306d.png)
