### PR TITLE
Remove `humanitarian-scope` from number of humanitarian activities definition

### DIFF
--- a/static/templates/humanitarian.html
+++ b/static/templates/humanitarian.html
@@ -63,7 +63,7 @@
           <p>The category that this self-defines themselves as for their IATI Regsitry account.</p>
 
           <h5>Number of Activities</h5>
-          <p>Total number of humanitarian activities (determined by use of <code>iati-activity/@humanitarian</code> attribute or <code>&lt;humanitarian-scope&gt;</code> element or DAC 5-digit sector codes between <code>72010</code> to <code>74010</code> inclusive, or DAC 3-digit sector codes <code>720</code>, <code>730</code> or <code>740</code>).</p>
+          <p>Total number of humanitarian activities (determined by use of <code>iati-activity/@humanitarian</code> attribute or DAC 5-digit sector codes between <code>72010</code> to <code>74010</code> inclusive, or DAC 3-digit sector codes <code>720</code>, <code>730</code> or <code>740</code>).</p>
 
           <h5>Publishing Humanitarian?</h5>
           <p>If the number of activities is greater than 0, then this is set at 100. Otherwise, this is set at 0.</p>


### PR DESCRIPTION
This makes the definition of the number of humanitarian activities consistent with the definition that was generally accepted via the consultation for the Grand Bargain Transparency Dashboard methodology.

Refs https://github.com/IATI/IATI-Dashboard/issues/485#issuecomment-396901278.