### PR TITLE
Make dashboard generation ~22x faster (from nearly 20 hours to less than an hour)

### DIFF
--- a/data.py
+++ b/data.py
@@ -13,9 +13,13 @@ def memoize(f):
     def wrapper(self, key):
         if not hasattr(self, '__cache'):
             self.__cache = {}
-        if key not in self.__cache:
-            self.__cache[key] = f(self, key)
-        return self.__cache[key]
+        if key in self.__cache:
+            return self.__cache[key]
+        res = f(self, key)
+        if type(res) is not JSONDir:
+            # don't cache JSONDirs
+            self.__cache[key] = res
+        return res
     return wrapper
 
 

--- a/data.py
+++ b/data.py
@@ -1,10 +1,54 @@
 import json
 from collections import OrderedDict, defaultdict
+from functools import partial
 import sys, os, re, copy, datetime, unicodecsv
 import UserDict
 import csv
 
 publisher_re = re.compile('(.*)\-[^\-]')
+
+
+class memoize(object):
+    """From:
+    http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
+
+    cache the return value of a method
+
+    This class is meant to be used as a decorator of methods. The return value
+    from a given method invocation will be cached on the instance whose method
+    was invoked. All arguments passed to a method decorated with memoize must
+    be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method:
+    class Obj(object):
+        @memoize
+        def add_to(self, arg):
+            return self + arg
+    Obj.add_to(1) # not enough arguments
+    Obj.add_to(1, 2) # returns 3, result is not cached
+    """
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
+
 
 class GroupFiles(object, UserDict.DictMixin):
     def __init__(self, inputdict):
@@ -64,6 +108,7 @@ class JSONDir(object, UserDict.DictMixin):
         """
         self.folder = folder
 
+    @memoize
     def __getitem__(self, key):
         """Define how variables are gathered from the raw JSON files and then parsed into
            the OrderedDict that will be returned.

--- a/data.py
+++ b/data.py
@@ -1,6 +1,5 @@
 import json
 from collections import OrderedDict, defaultdict
-from functools import partial
 import sys, os, re, copy, datetime, unicodecsv
 import UserDict
 import csv
@@ -8,46 +7,16 @@ import csv
 publisher_re = re.compile('(.*)\-[^\-]')
 
 
-class memoize(object):
-    """From:
-    http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
-
-    cache the return value of a method
-
-    This class is meant to be used as a decorator of methods. The return value
-    from a given method invocation will be cached on the instance whose method
-    was invoked. All arguments passed to a method decorated with memoize must
-    be hashable.
-
-    If a memoized method is invoked directly on its class the result will not
-    be cached. Instead the method will be invoked like a static method:
-    class Obj(object):
-        @memoize
-        def add_to(self, arg):
-            return self + arg
-    Obj.add_to(1) # not enough arguments
-    Obj.add_to(1, 2) # returns 3, result is not cached
-    """
-    def __init__(self, func):
-        self.func = func
-
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self.func
-        return partial(self, obj)
-
-    def __call__(self, *args, **kw):
-        obj = args[0]
-        try:
-            cache = obj.__cache
-        except AttributeError:
-            cache = obj.__cache = {}
-        key = (self.func, args[1:], frozenset(kw.items()))
-        try:
-            res = cache[key]
-        except KeyError:
-            res = cache[key] = self.func(*args, **kw)
-        return res
+# Modified from:
+#   https://github.com/IATI/IATI-Stats/blob/1d20ed1e/stats/common/decorators.py#L5-L13
+def memoize(f):
+    def wrapper(self, key):
+        if not hasattr(self, '__cache'):
+            self.__cache = {}
+        if key not in self.__cache:
+            self.__cache[key] = f(self, key)
+        return self.__cache[key]
+    return wrapper
 
 
 class GroupFiles(object, UserDict.DictMixin):

--- a/data.py
+++ b/data.py
@@ -77,24 +77,6 @@ class GroupFiles(object, UserDict.DictMixin):
         self.cache[key] = out
         return out
 
-def JSONDir_to_memory(JSONDir_obj):
-    """Copies data from a JSONDir object to an in-memory OrderedDict.
-       Use sparingly due to the memory that copying publisher data consumes!
-    Input: JSONDir_obj - a JSONDir object
-    Returns: An in-memory OrderedDict
-    """
-
-    output_data = OrderedDict()
-
-    # Loop over data within the JSONDir_obj and add to output data
-    for publisher, agg in JSONDir_obj.items():
-        output_data_sub = OrderedDict()
-        for k,v in agg.items():
-           output_data_sub.update({k: v})
-        output_data.update({publisher: output_data_sub})
-
-    return output_data
-
 
 class JSONDir(object, UserDict.DictMixin):
     """Produces an object, to be used to access JSON-formatted publisher data and return


### PR DESCRIPTION
## Summary

Instead of **19.5 hours**, this PR means all IATI-Dashboard operations (generating plots; generating CSV; generating HTML) complete in **under an hour**.

## Description

The dashboard currently does a lot of reading from disk. In fact, in many cases it reads the same JSON data from disk, over and over, hundreds of times. If we instead cache that JSON data after its first use, we switch from doing lots of reading from disk (slow) to lots of reading from memory (fast). This affords significant performance gains.

This is an updated version of #483. It fixes #482; and also fixes #494.

## What was wrong with #483?

When `JSONDir.__getitem__` returns another JSONDir, #483 ended up recursively caching, which quickly ate up memory. Here, I’ve modified it so that if `JSONDir.__getitem__` returns a JSONDir object, it isn’t cached.

## Performance

Without this fix:

```shell
$ time python plots.py 1> /dev/null

real    153m3.802s
user    57m39.798s
sys     24m46.134s

$ # user + sys = 1:22:25
$
$ time python make_csv.py 1> /dev/null

real    63m19.731s
user    17m10.463s
sys     13m56.338s

$ # user + sys = 31:06
$
$ time python make_html.py 1> /dev/null

real    1071m15.637s
user    991m50.619s
sys     61m0.988s

$ # user + sys = 17:32:50
```

That’s a total of about 19.5 hours.

With this fix:

```shell
$ time python plots.py 1> /dev/null

real    22m48.462s
user    20m17.230s
sys     0m51.087s

$ # user + sys = 21:08
$
$ time python make_csv.py 1> /dev/null

real    2m51.241s
user    1m40.066s
sys     1m1.371s

$ # user + sys = 2:41
$
$ time python make_html.py 1> /dev/null

real    29m30.090s
user    20m33.463s
sys     7m18.176s

$ # user + sys = 27:51
```

That’s a total of about 52 minutes.