### PR TITLE
Remove list of all publishers from various pages

### DIFF
--- a/static/templates/data_quality.html
+++ b/static/templates/data_quality.html
@@ -3,4 +3,3 @@
 <p>This section of the IATI Dashboard tracks published IATI data around a series of quality measures.</p> 
 <p>These are specifically technical measures - schema validation, download issues, XML formatting, etc - that can be easily rectified by publishers.  No attempt is made to evaluate the actual content of the data - the dashboard should be used for sense checking and technical fixes.</p>
 {% endblock about %}
-{% block publisher_page_hash %}#h_dataquality{% endblock %}

--- a/static/templates/exploring_data.html
+++ b/static/templates/exploring_data.html
@@ -3,4 +3,3 @@
 This section tracks the various elements, attributes and codelists within published IATI data.  
 For every instance of these properties, a report is made available.  
 {% endblock about %}
-{% block publisher_page_hash %}#h_exploringdata{% endblock %}

--- a/static/templates/publishing_stats.html
+++ b/static/templates/publishing_stats.html
@@ -19,6 +19,3 @@
 <p>The overriding concern of the Technical Team is that the methodologies being tested here gain buy-in from our members and publishers so that they can be used as a credible benchmark in improving the quality of IATI data.</p>
 
 {% endblock about %}
-
-{% block publishers %}
-{% endblock publishers %}

--- a/static/templates/section_index.html
+++ b/static/templates/section_index.html
@@ -40,11 +40,4 @@
 
     </div>
 
-{% block publishers %}
-<h3>Publishers</h3>
-{% for publisher_title,publisher in publishers_ordered_by_title %}
-<li><a href="publisher/{{publisher}}.html{% block publisher_page_hash%}{% endblock %}">{{publisher_title}}</a></li>
-{% endfor %}
-{% endblock %}
-
 {% endblock content %}


### PR DESCRIPTION
A number of pages include a list of all publishers, but it’s unclear what this list adds. It’s really long:
![vid1](https://user-images.githubusercontent.com/464193/43065577-2d838222-8e5a-11e8-913c-4727780bbee3.gif)

The [publishers page](http://dashboard.iatistandard.org/publishers.html) includes a much nicer presentation of this, and includes extra information about each publisher.

This PR removes the bulleted list of publishers, in favour of the publishers page.