### PR TITLE
Add undocumented requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Requirements:
 * Unix based setup (e.g. Linux, Mac OS X) with bash etc.
 * wget and curl installed
 * Python 2.7
+* Python dev library ``python-dev``
 * python-virtualenv (optional)
 * Development files for libfreetype, libpng, libxml and libxslt e.g. ``libfreetype6-dev libpng-dev libxml2-dev libxslt-dev``.
 


### PR DESCRIPTION
The `python-dev` library is needed to install matplotlib.

Note: I would provide an output from terminal to show the problem, but I have now installed `python-dev` locally and would need to uninstall to show the problem - maybe I'll do this at a later point (am currently running `get-stats.sh`)