### PR TITLE
Fixes cURL command flag for retreiving pre-generated data

### DIFF
--- a/get_stats.sh
+++ b/get_stats.sh
@@ -2,7 +2,7 @@
 # but with only the dated historical aggregates.
 mkdir stats-calculated
 for f in ckan gitdate; do
-    curl --compress "http://dashboard.iatistandard.org/stats/${f}.json" > stats-calculated/${f}.json
+    curl --compressed "http://dashboard.iatistandard.org/stats/${f}.json" > stats-calculated/${f}.json
 done
 
 mkdir stats-blacklist


### PR DESCRIPTION
Previous cURL command raises an error: `curl: option --compress: is ambiguous`
Not sure where the previously-used `--compress` flag came from, since it appears to have always been `--compressed` since at least 2012 - i.e. before this repo began!