### PR TITLE
Combine comprehensiveness budget and budget-not-provided

### DIFF
--- a/comprehensiveness.py
+++ b/comprehensiveness.py
@@ -87,14 +87,11 @@ def get_hierarchy_with_most_budgets(stats):
     try:
         # Get the key with the largest number of budgets
         budgets = max(stats['by_hierarchy'], key=(lambda x:
-            stats['by_hierarchy'][x]['comprehensiveness'].get('budget', 0)
-             if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
-        )
-        budget_not_provided = max(stats['by_hierarchy'], key=(lambda x:
+            stats['by_hierarchy'][x]['comprehensiveness'].get('budget', 0) +
             stats['by_hierarchy'][x]['comprehensiveness'].get('budget_not_provided', 0)
-             if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
+            if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
         )
-        return max(budgets, budget_not_provided)
+        return max(budgets)
     except KeyError:
         # Return None if this publisher has no comprehensiveness data in any hierarchy - i.e. KeyError
         return None
@@ -148,10 +145,12 @@ def generate_row(publisher):
             publisher_base = publisher_stats
 
         if slug == 'budget':
-            numerator_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
-            + publisher_base.get('comprehensiveness', {}).get('budget_not_provided', 0)
-            numerator_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)
-            + publisher_base.get('comprehensiveness_with_validation', {}).get('budget_not_provided', 0)
+            budget_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
+            budget_not_provided_all = publisher_base.get('comprehensiveness', {}).get('budget_not_provided', 0)
+            numerator_all = budget_all + budget_not_provided_all
+            budget_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)
+            budget_not_provided_valid = publisher_base.get('comprehensiveness_with_validation', {}).get('budget_not_provided', 0)
+            numerator_valid = budget_valid + budget_not_provided_valid
         else:
             numerator_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
             numerator_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)

--- a/comprehensiveness.py
+++ b/comprehensiveness.py
@@ -86,10 +86,15 @@ def get_hierarchy_with_most_budgets(stats):
 
     try:
         # Get the key with the largest number of budgets
-        return max(stats['by_hierarchy'], key=(lambda x:
+        budgets = max(stats['by_hierarchy'], key=(lambda x:
             stats['by_hierarchy'][x]['comprehensiveness'].get('budget', 0)
              if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
-          )
+        )
+        budget_not_provided = max(stats['by_hierarchy'], key=(lambda x:
+            stats['by_hierarchy'][x]['comprehensiveness'].get('budget_not_provided', 0)
+             if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
+        )
+        return max(budgets, budget_not_provided)
     except KeyError:
         # Return None if this publisher has no comprehensiveness data in any hierarchy - i.e. KeyError
         return None
@@ -142,8 +147,14 @@ def generate_row(publisher):
             # Most common case will be column_base_lookup[slug] == 'all':
             publisher_base = publisher_stats
 
-        numerator_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
-        numerator_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)
+        if slug == 'budget':
+            numerator_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
+            + publisher_base.get('comprehensiveness', {}).get('budget_not_provided', 0)
+            numerator_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)
+            + publisher_base.get('comprehensiveness_with_validation', {}).get('budget_not_provided', 0)
+        else:
+            numerator_all = publisher_base.get('comprehensiveness', {}).get(slug, 0)
+            numerator_valid = publisher_base.get('comprehensiveness_with_validation', {}).get(slug, 0)
 
         if denominator(slug, publisher_base) != 0:
             # Populate the row with the %age

--- a/comprehensiveness.py
+++ b/comprehensiveness.py
@@ -91,7 +91,7 @@ def get_hierarchy_with_most_budgets(stats):
             stats['by_hierarchy'][x]['comprehensiveness'].get('budget_not_provided', 0)
             if stats['by_hierarchy'][x]['comprehensiveness_denominator_default'] > 0 else None)
         )
-        return max(budgets)
+        return budgets
     except KeyError:
         # Return None if this publisher has no comprehensiveness data in any hierarchy - i.e. KeyError
         return None

--- a/plots.py
+++ b/plots.py
@@ -65,8 +65,6 @@ def make_plot(stat_path, git_stats, img_prefix=''):
         stat_name = stat_path[0]
     else:
         stat_name = stat_path
-    
-    print('-> ', stat_name)
    
     stat_dict = git_stats.get(stat_name)
     if not stat_dict:

--- a/plots.py
+++ b/plots.py
@@ -168,7 +168,6 @@ for stat_path in [
         ('publisher_types', lambda x: True, '' ),
         ('activities_per_publisher_type', lambda x: True, '' )
         ]:
-#    pdb.set_trace()
     make_plot(stat_path, git_stats)
 
 # Delete git_stats variable to save memory
@@ -181,7 +180,6 @@ except OSError:
 
 git_stats_publishers = AugmentedJSONDir('./stats-calculated/gitaggregate-publisher-dated/')
 for publisher, git_stats_publisher in git_stats_publishers.iteritems():
-    print(publisher)
     for stat_path in [
             'activities',
             'activity_files',
@@ -194,4 +192,3 @@ for publisher, git_stats_publisher in git_stats_publishers.iteritems():
             ('versions', lambda x: True, ''),
             ]:
         make_plot(stat_path, git_stats_publisher, 'publisher_imgs/{0}_'.format(publisher))
-


### PR DESCRIPTION
Addressing #539, first checking that the returned hierarchy is the one that contains the max number of either `budget` or `budget_not_provided`. 
The numerators for the column are a combination of budget and budget_not_provided values, and they are applied for `comprehensiveness_with_validation` as well. 