### PR TITLE
Ignore missing publishers

### DIFF
--- a/data.py
+++ b/data.py
@@ -231,7 +231,10 @@ codelist_sets = {
 #Simple look up to map publisher id to a publishers given name (title)
 publisher_name={publisher:publisher_json['result']['title'] for publisher,publisher_json in ckan_publishers.items()}
 #Create a list of tuples ordered by publisher given name titles - this allows us to display lists of publishers in alphabetical order
-publishers_ordered_by_title = [ (publisher_name[publisher],publisher) for publisher in current_stats['inverted_publisher']['activities'] if publisher in publisher_name]
+publishers_ordered_by_title = [
+    (publisher_name[publisher], publisher)
+    for publisher in current_stats['inverted_publisher']['activities']
+    if publisher in publisher_name]
 publishers_ordered_by_title.sort(key=lambda x: unicode.lower(x[0]))
 
 # List of publishers who report all their activities as a secondary publisher

--- a/data.py
+++ b/data.py
@@ -231,7 +231,7 @@ codelist_sets = {
 #Simple look up to map publisher id to a publishers given name (title)
 publisher_name={publisher:publisher_json['result']['title'] for publisher,publisher_json in ckan_publishers.items()}
 #Create a list of tuples ordered by publisher given name titles - this allows us to display lists of publishers in alphabetical order
-publishers_ordered_by_title = [ (publisher_name[publisher],publisher) for publisher in current_stats['inverted_publisher']['activities'] ]
+publishers_ordered_by_title = [ (publisher_name[publisher],publisher) for publisher in current_stats['inverted_publisher']['activities'] if publisher in publisher_name]
 publishers_ordered_by_title.sort(key=lambda x: unicode.lower(x[0]))
 
 # List of publishers who report all their activities as a secondary publisher

--- a/make_csv.py
+++ b/make_csv.py
@@ -10,6 +10,8 @@ publisher_name={publisher:publisher_json['result']['title'] for publisher,publis
 
 def publisher_dicts():
     for publisher, activities in data.current_stats['inverted_publisher']['activities'].items():
+        if publisher not in data.ckan_publishers:
+            continue
         publisher_stats = data.get_publisher_stats(publisher)
         yield {
             'Publisher Name': publisher_name[publisher],

--- a/static/templates/publisher.html
+++ b/static/templates/publisher.html
@@ -57,7 +57,7 @@
             </tr>
             <tr>
                 <td>Reporting Org on Registry</td>
-                <td>{% if ckan_publishers %}
+                <td>{% if ckan_publishers and publisher in ckan_publishers %}
                     <code>{{ckan_publishers[publisher].result.publisher_iati_id}}</code>
                     {% endif %}
                 </td>


### PR DESCRIPTION
If I create a fresh dashboard install, the following commands all fail with `KeyError`s:

```
python plots.py
python make_csv.py
python make_html.py
```

This PR fixes that, by ignoring publishers that are not present in data/ckan_publishers.