### PR TITLE
Remove protocol from asset links

### DIFF
--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="http://styles.iatistandard.org/assets/css/screen.css" rel="stylesheet">
+  <link href="//styles.iatistandard.org/assets/css/screen.css" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
   <link rel="icon" type="image/png" href="?" />
   <title>{% block title %}IATI Dashboard - {{page_titles[page]}}{% endblock %}</title>
@@ -204,7 +204,7 @@ html,body{height:100%;}
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/jquery.tablesorter.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/jquery.tablesorter.widgets.min.js"></script>
 {% block tablesorterscript %}<script>$(function() { $("{% block tablesortertarget %}table.table{% endblock %}").tablesorter({% block tablesorteroptions %}{% endblock %}); });</script>{% endblock %}
-<script src="http://styles.iatistandard.org/assets/js/app.bundle.js"></script>
+<script src="//styles.iatistandard.org/assets/js/app.bundle.js"></script>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
If the dashboard is served over SSL, these protocols result in mixed content warnings.