### PR TITLE
Prefer default vocabulary (if a default exists)

### DIFF
--- a/data.py
+++ b/data.py
@@ -211,7 +211,13 @@ def transform_codelist_mapping_keys(codelist_mapping):
     return codelist_mapping
 
 def create_codelist_mapping(major_version):
-    codelist_mapping = {x['path']:x['codelist'] for x in json.load(open('data/IATI-Codelists-{}/out/clv2/mapping.json'.format(major_version)))}
+    codelist_mapping = {}
+    for x in json.load(open('data/IATI-Codelists-{}/out/clv2/mapping.json'.format(major_version))):
+        if 'condition' in x \
+                and x['path'] in codelist_mapping \
+                and not re.search(r'not\([^)]+\)', x['condition']):
+            continue
+        codelist_mapping[x['path']] = x['codelist']
     return transform_codelist_mapping_keys(codelist_mapping)
 
 MAJOR_VERSIONS = ['2', '1']


### PR DESCRIPTION
# The problem

Some attributes can contain values from different codelists, depending on the `@vocabulary` used. The dashboard doesn’t have a means of showing this, as per the yellow banner shown on dashboard codelists, and #174.

Given the dashboard doesn’t have the functionality to select from multiple vocabularies, it needs to choose which vocabulary to use. Where a default vocabulary exists, it seems to make sense to prefer that one. That doesn’t necessarily happen at the moment, so this PR fixes that.

So for example, in the case of [`iati-activity/sector/@code`](http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/sector/#attributes), the default vocabulary is [`Sector`](http://reference.iatistandard.org/203/codelists/Sector/). However, [the dashboard currently uses the SectorCategory vocabulary](http://dashboard.iatistandard.org/codelist/2/sector_@code.html):

![Screenshot 2019-11-23 at 14 24 09](https://user-images.githubusercontent.com/464193/69480172-f0238200-0dfc-11ea-8681-84b42a1d5e70.png)

Similarly (as reported in #567), [`iati-activity/default-aid-type/@code`](http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/default-aid-type/#attributes) uses the [AidType](http://reference.iatistandard.org/203/codelists/AidType/) vocabulary by default. However, [the dashboard currently uses](http://dashboard.iatistandard.org/codelist/2/default-aid-type_@code.html) the (rarely used) [CashAndVoucherModalities vocabulary](http://reference.iatistandard.org/203/codelists/CashandVoucherModalities/):
![Screenshot 2019-11-23 at 14 27 26](https://user-images.githubusercontent.com/464193/69480226-85bf1180-0dfd-11ea-9058-13fb911ff7f1.png)

# The proposed solution

This PR ensures that when a default vocabulary exists for a given attribute, it is preferred on dashboard codelist pages.

For `iati-activity/sector/@code`, that’s Sector:
![Screenshot 2019-11-23 at 14 30 28](https://user-images.githubusercontent.com/464193/69480257-d20a5180-0dfd-11ea-95b6-b4e73d480e89.png)

For `iati-activity/default-aid-type/@code`, that’s AidType:
![Screenshot 2019-11-23 at 14 31 27](https://user-images.githubusercontent.com/464193/69480269-f6662e00-0dfd-11ea-9e6a-bd012c0db19a.png)

It’s worth noting that for a small number of IATI attributes, there is no default codelist. For example, [`iati-activity/tag/@code`](http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/tag/#attributes). In such cases, we use the codelist for the first mapping for that attribute found in the mapping file.

Fixes #567.