### PR TITLE
Reduce page size to 50

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -18,7 +18,7 @@ try:
 except OSError:
     pass
 
-page_size = 100
+page_size = 50
 url = 'https://iatiregistry.org/api/3/action/organization_list'
 params = {
     'all_fields': 'true',


### PR DESCRIPTION
https://iatiregistry.org/api/3/action/organization_list?all_fields=true&limit=100
…only returns 50 results.

I guess this is set as a hard limit on the registry. [CKAN 2.9 documentation](https://docs.ckan.org/en/2.9/api/#ckan.logic.action.get.organization_list) suggests this is set in site’s configuration `ckan.group_and_organization_list_all_fields_max`.

So this could either be fixed in the registry config, or by reducing the page size here.