### PR TITLE
lint: Extend list of ignored flake8 errors, instead of overwriting it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501
+extend-ignore = E501


### PR DESCRIPTION
@chrisarridge I've decided to just make the setup.cfg change for now, which ignores the `+` at start/end of lines entirely, as we'll look at fixing linting automatically with black later.