### PR TITLE
Fix/update packages

### DIFF
--- a/make_html.py
+++ b/make_html.py
@@ -231,7 +231,7 @@ def basic_page(page_name):
 
 @app.route('/data/download_errors.json')
 def download_errors_json():
-    return Response(json.dumps(current_stats['download_errors'], indent=2), mimetype='application/json'),
+    return Response(json.dumps(current_stats['download_errors'], indent=2), mimetype='application/json')
 
 
 @app.route('/')

--- a/make_html.py
+++ b/make_html.py
@@ -9,7 +9,6 @@ import subprocess
 from collections import defaultdict
 
 from flask import Flask, render_template, abort, Response, send_from_directory
-import pytz
 
 import licenses
 import timeliness
@@ -20,7 +19,7 @@ import summary_stats
 import humanitarian
 from vars import expected_versions
 import text
-from datetime import datetime
+from datetime import datetime, UTC
 from dateutil import parser
 from data import (
     ckan,
@@ -121,7 +120,7 @@ app.jinja_env.filters['round_nicely'] = round_nicely
 # Custom Jinja globals
 app.jinja_env.globals['dataset_to_publisher'] = dataset_to_publisher
 app.jinja_env.globals['url'] = lambda x: '/' if x == 'index.html' else x
-app.jinja_env.globals['datetime_generated'] = lambda: datetime.utcnow().replace(tzinfo=pytz.utc).strftime('%-d %B %Y (at %H:%M %Z)')
+app.jinja_env.globals['datetime_generated'] = lambda: datetime.now(UTC).strftime('%-d %B %Y (at %H:%M %Z)')
 app.jinja_env.globals['datetime_data'] = date_time_data_obj.strftime('%-d %B %Y (at %H:%M %Z)')
 app.jinja_env.globals['commit_hash'] = subprocess.run(
     'git show --format=%H --no-patch'.split(),
@@ -152,7 +151,7 @@ app.jinja_env.globals['get_publisher_stats'] = get_publisher_stats
 app.jinja_env.globals['set'] = set
 app.jinja_env.globals['firstint'] = firstint
 app.jinja_env.globals['expected_versions'] = expected_versions
-app.jinja_env.globals['current_year'] = datetime.utcnow().year
+app.jinja_env.globals['current_year'] = datetime.now(UTC).year
 # Following variables set in coverage branch but not in master
 # app.jinja_env.globals['float'] = float
 # app.jinja_env.globals['dac2012'] = dac2012

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,12 @@
-flask==0.12.3
-frozen-flask==0.15
-jinja2==2.11.3
+flask==3.0.3
+frozen-flask==1.0.2
+jinja2==3.1.2
 python-dateutil==2.8.1
 pytz
 matplotlib==3.9.0
-werkzeug==0.16.1
+werkzeug==3.0.0
 xmlschema==1.6.2
 lxml
 requests
-markupsafe==2.0.1
-itsdangerous==2.0.1     # Pinned as >2.0.1 drops itsdangerous.json
+markupsafe==2.1.1
+itsdangerous==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+blinker==1.8.2
+    # via flask
 certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
@@ -16,21 +18,21 @@ cycler==0.12.1
     # via matplotlib
 elementpath==2.5.3
     # via xmlschema
-flask==0.12.3
+flask==3.0.3
     # via
     #   -r requirements.in
     #   frozen-flask
 fonttools==4.53.1
     # via matplotlib
-frozen-flask==0.15
+frozen-flask==1.0.2
     # via -r requirements.in
 idna==3.7
     # via requests
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements.in
     #   flask
@@ -38,10 +40,11 @@ kiwisolver==1.4.5
     # via matplotlib
 lxml==5.2.2
     # via -r requirements.in
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements.in
     #   jinja2
+    #   werkzeug
 matplotlib==3.9.0
     # via -r requirements.in
 numpy==2.0.0
@@ -66,7 +69,7 @@ six==1.16.0
     # via python-dateutil
 urllib3==2.2.2
     # via requests
-werkzeug==0.16.1
+werkzeug==3.0.0
     # via
     #   -r requirements.in
     #   flask

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements_dev.in
 #
+blinker==1.8.2
+    # via
+    #   -r requirements.txt
+    #   flask
 certifi==2024.7.4
     # via
     #   -r requirements.txt
@@ -40,7 +44,7 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.7
     # via -r requirements_dev.in
-flask==0.12.3
+flask==3.0.3
     # via
     #   -r requirements.txt
     #   frozen-flask
@@ -48,7 +52,7 @@ fonttools==4.53.1
     # via
     #   -r requirements.txt
     #   matplotlib
-frozen-flask==0.15
+frozen-flask==1.0.2
     # via -r requirements.txt
 idna==3.7
     # via
@@ -56,11 +60,11 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   -r requirements.txt
     #   flask
-jinja2==2.11.3
+jinja2==3.1.2
     # via
     #   -r requirements.txt
     #   flask
@@ -70,10 +74,11 @@ kiwisolver==1.4.5
     #   matplotlib
 lxml==5.2.2
     # via -r requirements.txt
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements.txt
     #   jinja2
+    #   werkzeug
 matplotlib==3.9.0
     # via -r requirements.txt
 mccabe==0.6.1
@@ -126,7 +131,7 @@ urllib3==2.2.2
     # via
     #   -r requirements.txt
     #   requests
-werkzeug==0.16.1
+werkzeug==3.0.0
     # via
     #   -r requirements.txt
     #   flask


### PR DESCRIPTION
Version of `frozen-flask` was updated to be compatible with Python 3.12 and updated other dependencies as required.  This required a change to the return value from one of the view functions.  Also modified code to remove `datetime.datetime.utcnow()` deprecation warnings that were now appearing with Python 3.12.