### PR TITLE
Updates for compatibility with Python 3.12

### DIFF
--- a/fetch_github_issues.py
+++ b/fetch_github_issues.py
@@ -22,8 +22,8 @@ with open(Path('data/github/issues.json')) as f:
     issues = json.load(f)
 for issue in issues:
     awaiting_triage = [
-        l for l in issue['labels']
-        if l['name'] == 'awaiting triage']
+        x for x in issue['labels']
+        if x['name'] == 'awaiting triage']
     if awaiting_triage:
         # ignore these
         continue
@@ -38,7 +38,7 @@ for issue in issues:
             'created_at': issue['created_at'],
             'updated_at': issue['updated_at'],
             'state': issue['state'],
-            'labels': [l for l in issue['labels'] if not l['name'].startswith('publisher: ')],
+            'labels': [x for x in issue['labels'] if not x['name'].startswith('publisher: ')],
         })
 for pub_id, issues in publishers.items():
     with open(Path(f'data/github/publishers/{pub_id}.json'), 'w') as f:

--- a/forwardlooking.py
+++ b/forwardlooking.py
@@ -47,7 +47,7 @@ def generate_row(publisher):
 
     # Loop over each of the three years (i.e. this year and the following two years) to generate the statistics for the table
     for year in years:
-        if(len(hierarchies_with_budget_not_provided) > 0):
+        if (len(hierarchies_with_budget_not_provided) > 0):
             row['budget_not_provided'] = True
         # If 'forwardlooking_activities_current' and 'forwardlooking_activities_with_budgets' or 'forwardlooking_activities_with_budget_not_provided' are in the bottom hierarchy
         if 'forwardlooking_activities_current' in publisher_stats['bottom_hierarchy'] and ('forwardlooking_activities_with_budgets' in publisher_stats['bottom_hierarchy'] or 'forwardlooking_activities_with_budget_not_provided' in publisher_stats['bottom_hierarchy']):

--- a/make_html.py
+++ b/make_html.py
@@ -231,7 +231,7 @@ def basic_page(page_name):
 
 @app.route('/data/download_errors.json')
 def download_errors_json():
-    return Response(json.dumps(current_stats['download_errors'], indent=2), mimetype='application/json'),
+    return Response(json.dumps(current_stats['download_errors'], indent=2), mimetype='application/json')
 
 
 @app.route('/')

--- a/make_html.py
+++ b/make_html.py
@@ -9,7 +9,6 @@ import subprocess
 from collections import defaultdict
 
 from flask import Flask, render_template, abort, Response, send_from_directory
-import pytz
 
 import licenses
 import timeliness
@@ -20,7 +19,7 @@ import summary_stats
 import humanitarian
 from vars import expected_versions
 import text
-from datetime import datetime
+from datetime import datetime, UTC
 from dateutil import parser
 from data import (
     ckan,
@@ -121,7 +120,7 @@ app.jinja_env.filters['round_nicely'] = round_nicely
 # Custom Jinja globals
 app.jinja_env.globals['dataset_to_publisher'] = dataset_to_publisher
 app.jinja_env.globals['url'] = lambda x: '/' if x == 'index.html' else x
-app.jinja_env.globals['datetime_generated'] = lambda: datetime.utcnow().replace(tzinfo=pytz.utc).strftime('%-d %B %Y (at %H:%M %Z)')
+app.jinja_env.globals['datetime_generated'] = lambda: datetime.now(UTC).strftime('%-d %B %Y (at %H:%M %Z)')
 app.jinja_env.globals['datetime_data'] = date_time_data_obj.strftime('%-d %B %Y (at %H:%M %Z)')
 app.jinja_env.globals['commit_hash'] = subprocess.run(
     'git show --format=%H --no-patch'.split(),
@@ -152,7 +151,7 @@ app.jinja_env.globals['get_publisher_stats'] = get_publisher_stats
 app.jinja_env.globals['set'] = set
 app.jinja_env.globals['firstint'] = firstint
 app.jinja_env.globals['expected_versions'] = expected_versions
-app.jinja_env.globals['current_year'] = datetime.utcnow().year
+app.jinja_env.globals['current_year'] = datetime.now(UTC).year
 # Following variables set in coverage branch but not in master
 # app.jinja_env.globals['float'] = float
 # app.jinja_env.globals['dac2012'] = dac2012

--- a/plots.py
+++ b/plots.py
@@ -50,7 +50,7 @@ class AugmentedJSONDir(data.JSONDir):
 
 
 def make_plot(stat_path, git_stats, img_prefix=''):
-    if type(stat_path) == tuple:
+    if type(stat_path) is tuple:
         stat_name = stat_path[0]
     else:
         stat_name = stat_path
@@ -60,7 +60,7 @@ def make_plot(stat_path, git_stats, img_prefix=''):
         return
     items = sorted(stat_dict.items())
     x_values = [datetime.date(int(x[0:4]), int(x[5:7]), int(x[8:10])) for x, y in items]
-    if type(stat_path) == tuple:
+    if type(stat_path) is tuple:
         y_values = [dict((k, v) for k, v in y.items() if stat_path[1](k)) for x, y in items]
     else:
         y_values = [float(y) for x, y in items]
@@ -75,7 +75,7 @@ def make_plot(stat_path, git_stats, img_prefix=''):
     dpi = 96
     fig.set_size_inches(600.0 / dpi, 600.0 / dpi)
 
-    if type(y_values[0]) == dict:
+    if type(y_values[0]) is dict:
         keys = set([tm for y in y_values for tm in y.keys()])
         plots = {}
         for key in keys:
@@ -115,7 +115,7 @@ def make_plot(stat_path, git_stats, img_prefix=''):
 
     ax.ticklabel_format(axis='y', style='plain', useOffset=False)
 
-    fig.savefig('out/{0}{1}{2}.png'.format(img_prefix, stat_name, stat_path[2] if type(stat_path) == tuple else ''), dpi=dpi)
+    fig.savefig('out/{0}{1}{2}.png'.format(img_prefix, stat_name, stat_path[2] if type(stat_path) is tuple else ''), dpi=dpi)
     plt.close('all')
 
     fn = 'out/{0}{1}.csv'.format(img_prefix, stat_name)

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,12 @@
-flask==0.12.3
-frozen-flask==0.15
-jinja2==2.11.3
-python-dateutil==2.8.1
+flask
+frozen-flask
+jinja2
+python-dateutil
 pytz
-matplotlib==3.9.0
-werkzeug==0.16.1
-xmlschema==1.6.2
+matplotlib
+werkzeug
+xmlschema
 lxml
 requests
-markupsafe==2.0.1
-itsdangerous==2.0.1     # Pinned as >2.0.1 drops itsdangerous.json
+markupsafe
+itsdangerous

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+blinker==1.8.2
+    # via flask
 certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
@@ -14,37 +16,38 @@ contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-elementpath==2.5.3
+elementpath==4.4.0
     # via xmlschema
-flask==0.12.3
+flask==3.0.3
     # via
     #   -r requirements.in
     #   frozen-flask
 fonttools==4.53.1
     # via matplotlib
-frozen-flask==0.15
+frozen-flask==1.0.2
     # via -r requirements.in
 idna==3.7
     # via requests
-itsdangerous==2.0.1
+itsdangerous==2.2.0
     # via
     #   -r requirements.in
     #   flask
-jinja2==2.11.3
+jinja2==3.1.4
     # via
     #   -r requirements.in
     #   flask
 kiwisolver==1.4.5
     # via matplotlib
-lxml==5.2.2
+lxml==5.3.0
     # via -r requirements.in
-markupsafe==2.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements.in
     #   jinja2
-matplotlib==3.9.0
+    #   werkzeug
+matplotlib==3.9.2
     # via -r requirements.in
-numpy==2.0.0
+numpy==2.0.1
     # via
     #   contourpy
     #   matplotlib
@@ -54,7 +57,7 @@ pillow==10.4.0
     # via matplotlib
 pyparsing==3.1.2
     # via matplotlib
-python-dateutil==2.8.1
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.in
     #   matplotlib
@@ -66,9 +69,9 @@ six==1.16.0
     # via python-dateutil
 urllib3==2.2.2
     # via requests
-werkzeug==0.16.1
+werkzeug==3.0.3
     # via
     #   -r requirements.in
     #   flask
-xmlschema==1.6.2
+xmlschema==3.3.2
     # via -r requirements.in

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==8.2.2
-pytest-cov==5.0.0
-coveralls==4.0.1
-flake8==3.7.7
+pytest
+pytest-cov
+coveralls
+flake8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements_dev.in
 #
+blinker==1.8.2
+    # via
+    #   -r requirements.txt
+    #   flask
 certifi==2024.7.4
     # via
     #   -r requirements.txt
@@ -20,7 +24,7 @@ contourpy==1.2.1
     # via
     #   -r requirements.txt
     #   matplotlib
-coverage[toml]==7.5.4
+coverage[toml]==7.6.1
     # via
     #   coveralls
     #   pytest-cov
@@ -32,15 +36,13 @@ cycler==0.12.1
     #   matplotlib
 docopt==0.6.2
     # via coveralls
-elementpath==2.5.3
+elementpath==4.4.0
     # via
     #   -r requirements.txt
     #   xmlschema
-entrypoints==0.3
-    # via flake8
-flake8==3.7.7
+flake8==7.1.1
     # via -r requirements_dev.in
-flask==0.12.3
+flask==3.0.3
     # via
     #   -r requirements.txt
     #   frozen-flask
@@ -48,7 +50,7 @@ fonttools==4.53.1
     # via
     #   -r requirements.txt
     #   matplotlib
-frozen-flask==0.15
+frozen-flask==1.0.2
     # via -r requirements.txt
 idna==3.7
     # via
@@ -56,11 +58,11 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.0.1
+itsdangerous==2.2.0
     # via
     #   -r requirements.txt
     #   flask
-jinja2==2.11.3
+jinja2==3.1.4
     # via
     #   -r requirements.txt
     #   flask
@@ -68,17 +70,18 @@ kiwisolver==1.4.5
     # via
     #   -r requirements.txt
     #   matplotlib
-lxml==5.2.2
+lxml==5.3.0
     # via -r requirements.txt
-markupsafe==2.0.1
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
-matplotlib==3.9.0
+    #   werkzeug
+matplotlib==3.9.2
     # via -r requirements.txt
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
-numpy==2.0.0
+numpy==2.0.1
     # via
     #   -r requirements.txt
     #   contourpy
@@ -94,21 +97,21 @@ pillow==10.4.0
     #   matplotlib
 pluggy==1.5.0
     # via pytest
-pycodestyle==2.5.0
+pycodestyle==2.12.1
     # via flake8
-pyflakes==2.1.1
+pyflakes==3.2.0
     # via flake8
 pyparsing==3.1.2
     # via
     #   -r requirements.txt
     #   matplotlib
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   -r requirements_dev.in
     #   pytest-cov
 pytest-cov==5.0.0
     # via -r requirements_dev.in
-python-dateutil==2.8.1
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   matplotlib
@@ -126,9 +129,9 @@ urllib3==2.2.2
     # via
     #   -r requirements.txt
     #   requests
-werkzeug==0.16.1
+werkzeug==3.0.3
     # via
     #   -r requirements.txt
     #   flask
-xmlschema==1.6.2
+xmlschema==3.3.2
     # via -r requirements.txt


### PR DESCRIPTION
Version of `frozen-flask` was found to be incompatible with Python 3.12.  Unpinned all requirements to get the latest package versions. This required a change to the return value from one of the view functions. Also modified code to remove `datetime.datetime.utcnow()` deprecation warnings that were now appearing with Python 3.12 and to fix some linting errors found with the latest version of `flake8`.