### PR TITLE
Fix/update validator links, remove Google Analytics and reinstate dev server

### DIFF
--- a/make_html.py
+++ b/make_html.py
@@ -250,33 +250,41 @@ if __name__ == '__main__':
     parser.add_argument("--url",
                         help="Link to connect dashboard to publishing stats",
                         default="")
+    parser.add_argument("--live", action="store_true",
+                        help="Run a development server")
     args = parser.parse_args()
     app.jinja_env.globals['pubstats_url'] = args.url
-    from flask_frozen import Freezer
-    app.config['FREEZER_DESTINATION'] = 'out'
-    app.config['FREEZER_REMOVE_EXTRA_FILES'] = False
-    app.debug = False    # Comment to turn off debugging
-    app.testing = True   # Comment to turn off debugging
-    freezer = Freezer(app)
 
-    @freezer.register_generator
-    def url_generator():
-        for page_name in basic_page_names:
-            yield 'basic_page', {'page_name': page_name}
-        for publisher in current_stats['inverted_publisher']['activities'].keys():
-            yield 'publisher', {'publisher': publisher}
-        for slug in slugs['element']['by_slug']:
-            yield 'element', {'slug': slug}
-        for major_version, codelist_slugs in slugs['codelist'].items():
-            for slug in codelist_slugs['by_slug']:
-                yield 'codelist', {
-                    'slug': slug,
-                    'major_version': major_version
-                }
-        for license in licenses.licenses:
-            if license is None:
-                license = 'None'
-            yield 'licenses_individual_license', {'license': license}
+    if args.live:
+        app.debug = True
+        app.run()
+
+    else:
+        from flask_frozen import Freezer
+        app.config['FREEZER_DESTINATION'] = 'out'
+        app.config['FREEZER_REMOVE_EXTRA_FILES'] = False
+        app.debug = False    # Comment to turn off debugging
+        app.testing = True   # Comment to turn off debugging
+        freezer = Freezer(app)
+
+        @freezer.register_generator
+        def url_generator():
+            for page_name in basic_page_names:
+                yield 'basic_page', {'page_name': page_name}
+            for publisher in current_stats['inverted_publisher']['activities'].keys():
+                yield 'publisher', {'publisher': publisher}
+            for slug in slugs['element']['by_slug']:
+                yield 'element', {'slug': slug}
+            for major_version, codelist_slugs in slugs['codelist'].items():
+                for slug in codelist_slugs['by_slug']:
+                    yield 'codelist', {
+                        'slug': slug,
+                        'major_version': major_version
+                    }
+            for license in licenses.licenses:
+                if license is None:
+                    license = 'None'
+                yield 'licenses_individual_license', {'license': license}
 
 
-    freezer.freeze()
+        freezer.freeze()

--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -223,15 +223,6 @@ html,body{height:100%;}
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.13.3/jquery.tablesorter.widgets.min.js"></script>
 {% block tablesorterscript %}<script>$(function() { $("{% block tablesortertarget %}table.table{% endblock %}").tablesorter({% block tablesorteroptions %}{% endblock %}); });</script>{% endblock %}
 <script src="//styles.iatistandard.org/assets/js/app.bundle.js"></script>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-47211623-3', 'dashboard.iatistandard.org');
-  ga('set', 'anonymizeIp', true);
-  ga('send', 'pageview');
-</script>
   {% block extrafooter %}{% endblock %}
 </body>
 </html>

--- a/static/templates/publisher.html
+++ b/static/templates/publisher.html
@@ -167,7 +167,7 @@
                     </div>
                     <div class="col-md-2 break">
                        {% if publisher in ckan and dataset in ckan[publisher] %}
-                       <a href="http://validator.iatistandard.org/?url={{ckan[publisher][dataset].resource.url|urlencode}}">validator</a>
+                       <a href="https://validator.iatistandard.org/report/{{ dataset }}">validator</a>
                        {% endif %}
                     </div>
                   </div>

--- a/static/templates/validation.html
+++ b/static/templates/validation.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="col-md-2 break">
                    {% if publisher in ckan and dataset in ckan[publisher] %}
-                   <a href="https://iativalidator.iatistandard.org/view/dqf/files/{{ckan[publisher][dataset].resource.package_id|urlencode}}">validator</a>
+                   <a href="https://validator.iatistandard.org/report/{{ dataset }}">validator</a>
                    {% endif %}
                 </div>
               </div>


### PR DESCRIPTION
This PR updates links to validator pages that were broken (https://github.com/IATI/IATI-Dashboard/issues/597) or pointed to an older page that then used a redirect to get to the correct endpoint.  The opportunity was also taken to remove Google Analytics.  As part of this work the development server (`python make_html.py --live`) was reinstated and which closes https://github.com/IATI/IATI-Dashboard/issues/569.