### PR TITLE
Fix to stats fetching script so it fetches JSON files via HTTPS

### DIFF
--- a/get_stats.sh
+++ b/get_stats.sh
@@ -2,7 +2,7 @@
 # but with only the dated historical aggregates.
 mkdir stats-calculated
 for f in ckan gitdate; do
-    curl --compressed "http://dashboard.iatistandard.org/stats/${f}.json" > stats-calculated/${f}.json
+    curl --compressed "https://dashboard.iatistandard.org/stats/${f}.json" > stats-calculated/${f}.json
 done
 
 mkdir stats-blacklist


### PR DESCRIPTION
Updated stats fetching script to get ckan.json and gitdate.json from dashboard.iatistandard.org via HTTPS rather than HTTP.