### PR TITLE
Refactor exploring data

### DIFF
--- a/dashboard/data.py
+++ b/dashboard/data.py
@@ -6,7 +6,7 @@ import re
 import csv
 from decimal import Decimal
 
-from xmlschema import XMLSchema
+import xmlschema
 
 import config
 
@@ -211,21 +211,28 @@ sources105 = [
 sources203 = [
     config.join_data_path('schemas/2.03/iati-activities-schema.xsd'),
     config.join_data_path('schemas/2.03/iati-organisations-schema.xsd')]
-schema105 = XMLSchema(sources105)
-schema203 = XMLSchema(sources203)
+schema105 = xmlschema.XMLSchema(sources105)
+schema203 = xmlschema.XMLSchema(sources203)
 
 
-def is_valid_element(path):
-    try:
-        if schema203.get_element(None, path=path):
-            return True
-    except AttributeError:
-        pass
-    try:
-        if schema105.get_element(None, path=path):
-            return True
-    except AttributeError:
-        pass
+def is_valid_element_or_attribute(path: str) -> bool:
+    """Checks to see if a path is in either the 2.03 or 1.05 schema
+
+    Parameters
+    ----------
+    path : str
+        Path to the element or attribute to find.
+
+    Returns
+    -------
+    bool
+        True if the path is a known element or attribute.
+    """
+    if isinstance(schema203.find(path), (xmlschema.XsdElement, xmlschema.XsdAttribute)):
+        return True
+    if isinstance(schema105.find(path), (xmlschema.XsdElement, xmlschema.XsdAttribute)):
+        return True
+
     return False
 
 

--- a/dashboard/templates/booleans.html
+++ b/dashboard/templates/booleans.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% import '_partials/boxes.html' as boxes %}
+{% import '_partials/boxes.html' as boxes with context%}
 
 {% block content %}
     <div class="row">

--- a/dashboard/templates/codelist.html
+++ b/dashboard/templates/codelist.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% import '_partials/boxes.html' as boxes %}
+{% import '_partials/boxes.html' as boxes with context %}
 
 {% block page_header %}
 <h1>Codelist values used for <code>{{ element }}</code></h1>
@@ -45,7 +45,7 @@
                   <tr><td>{{ value }}</td>
                     <td>{{ codelist_lookup[major_version].get(codelist_mapping[major_version].get(element))[value]['name'] }}</td>
                     <td>
-                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='{{ url_for('publisher', publisher=publisher) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
+                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in func.sorted(publishers.items()) %}<a href='{{ url('dash-headlines-publisher-detail', args=[publisher]) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
                   </td></tr>
                   {% endif %}
               {% endfor %}
@@ -68,7 +68,7 @@
               {% for value, publishers in values.items() %}
                   {% if not value in codelist_sets[major_version].get(codelist_mapping[major_version].get(element)) %}
                   <tr><td>{{ value }}</td><td>
-                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in sorted(publishers.items()) %}<a href='{{ url_for('publisher', publisher=publisher) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
+                      <a href="javascript: return false;" class="popover-html" title="Publishers using <code>{{ value }}</code>" role="button" tabindex="0" data-trigger="focus" data-content="{% for publisher, count in func.sorted(publishers.items()) %}<a href='{{ url('dash-headlines-publisher-detail', args=[publisher]) }}#p_codelists'>{{ publisher }}</a>:&nbsp;{{ count }}<br/> {% endfor %}">{{ publishers|length }}</a>
                   </td></tr>
                   {% endif %}
               {% endfor %}

--- a/dashboard/templates/codelists.html
+++ b/dashboard/templates/codelists.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% import '_partials/boxes.html' as boxes %}
+{% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
       <div class="col-xs-12">
@@ -25,17 +25,17 @@
               <th>Values used, not on Codelist</th>
             </tr></thead>
             <tbody>
-              {% for i, (element, values) in enumerate(current_stats.inverted_publisher.codelist_values_by_major_version[major_version].items()) %}
+              {% for i, (element, values) in func.enumerate(current_stats.inverted_publisher.codelist_values_by_major_version[major_version].items()) %}
                 <tr>
-                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ element }}</td>
+                  <td><a href="{{ url('dash-exploringdata-codelists-detail', args=[major_version, slugs.codelist[major_version].by_i[i]]) }}">{{ element }}</td>
                   <td><a href="http://iatistandard.org/codelists/{{ codelist_mapping[major_version].get(element) }}">{{ codelist_mapping[major_version].get(element) }}</a></td>
-                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ values|length }}</a></td>
+                  <td><a href="{{ url('dash-exploringdata-codelists-detail', args=[major_version, slugs.codelist[major_version].by_i[i]]) }}">{{ values|length }}</a></td>
                   <td><a href="http://iatistandard.org/codelists/{{ codelist_mapping[major_version].get(element) }}">{{ codelist_sets[major_version].get(codelist_mapping[major_version].get(element))|length }}</a></td>
-                  {% with codes=sorted(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)).intersection(get_codelist_values(values))) %}
-                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ codes|length }}</a></td>
+                  {% with codes=func.sorted(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)).intersection(func.get_codelist_values(values))) %}
+                  <td><a href="{{ url('dash-exploringdata-codelists-detail', args=[major_version, slugs.codelist[major_version].by_i[i]]) }}">{{ codes|length }}</a></td>
                   {% endwith %}
-                  {% with codes=sorted(set(get_codelist_values(values)).difference(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)))) %}
-                  <td><a href="{{ url_for('codelist', major_version=major_version, slug=slugs.codelist[major_version].by_i[i]) }}">{{ codes|length }}</a></td>
+                  {% with codes=func.sorted(func.set(func.get_codelist_values(values)).difference(codelist_sets[major_version].get(codelist_mapping[major_version].get(element)))) %}
+                  <td><a href="{{ url('dash-exploringdata-codelists-detail', args=[major_version, slugs.codelist[major_version].by_i[i]]) }}">{{ codes|length }}</a></td>
                   {% endwith %}
                 </tr>
               {% endfor %}

--- a/dashboard/templates/dates.html
+++ b/dashboard/templates/dates.html
@@ -17,9 +17,9 @@
             </tr></thead>
             <tbody>
               {% for publisher_title,publisher in publishers_ordered_by_title %}
-              {% set publisher_stats = get_publisher_stats(publisher) %}
+              {% set publisher_stats = func.get_publisher_stats(publisher) %}
                   <tr>
-                      <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
+                      <td><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher_title }}</a></td>
                       <td>{% if publisher_stats.date_extremes.min.overall %}{{ publisher_stats.date_extremes.min.overall }}{% endif %}</td>
                       <td>{% if publisher_stats.date_extremes.max.overall %}{{ publisher_stats.date_extremes.max.overall }}{% endif %}</td>
                       <td>{% if publisher_stats.date_extremes.max.by_type['start-actual'] %}{{ publisher_stats.date_extremes.max.by_type['start-actual'] }}{% endif %}</td>

--- a/dashboard/templates/element.html
+++ b/dashboard/templates/element.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% import '_partials/boxes.html' as boxes %}
+{% import '_partials/boxes.html' as boxes with context %}
 
 {% block page_header %}
   <h1>Usage of <code>{{ element }}</code></h1>
@@ -36,14 +36,14 @@
                 <td>Total activities</td>
           </thead>
           <tbody>
-            {% for publisher in sorted(publishers) %}
+            {% for publisher in func.sorted(publishers) %}
             <tr>
-                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
-                {% with publisher_inverted=get_publisher_stats(publisher, 'inverted-file') %}
+                <td><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher }}</a></td>
+                {% with publisher_inverted=func.get_publisher_stats(publisher, 'inverted-file') %}
                 <td><a href="#files_{{ publisher }}">{% if 'elements' in publisher_inverted %}{{ publisher_inverted.elements[element]|count }}{% endif %}</a></td>
                 {% endwith %}
                 <td>{{ current_stats.inverted_publisher.activity_files.get(publisher)+current_stats.inverted_publisher.organisation_files.get(publisher) }}</td>
-                {% with publisher_stats=get_publisher_stats(publisher) %}
+                {% with publisher_stats=func.get_publisher_stats(publisher) %}
                 <td>{{ publisher_stats.elements[element] }}</td>
                 <td>{{ publisher_stats.elements_total[element] }}</td>
                 {% endwith %}
@@ -71,7 +71,7 @@
             {% for publisher in current_stats.inverted_publisher.publishers %}
             {% if publisher not in publishers %}
             <tr>
-                <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td>
+                <td><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher }}</a></td>
                 <td>{{ current_stats.inverted_publisher.activity_files.get(publisher)+current_stats.inverted_publisher.organisation_files.get(publisher) }}</td>
                 <td>{{ current_stats.inverted_publisher.activities[publisher] }}</td>
                 <td>{{ current_stats.inverted_publisher.organisations[publisher] }}</td>
@@ -98,7 +98,7 @@
             {% for publisher in current_stats.inverted_file_publisher %}
               {% with datasets = current_stats.inverted_file_publisher[publisher].elements.get(element) %}
               {% if datasets %}
-                <tr><td id="files_{{ publisher }}"><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher }}</a></td><td>
+                <tr><td id="files_{{ publisher }}"><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher }}</a></td><td>
                 {% for dataset in datasets.keys() %}
                     <a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a>
                 {% endfor %}

--- a/dashboard/templates/elements.html
+++ b/dashboard/templates/elements.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% import '_partials/boxes.html' as boxes %}
+{% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
     <div class="col-md-6">
     <div class="panel panel-default">
         <div class="panel-body">
             <p>Download this data as CSV: <ul>
-                <li><a href="{{ url_for('static', filename='elements.csv') }}">Activities/Orgs with element/attribute per publisher</a></li>
-                <li><a href="{{ url_for('static', filename='elements_total.csv') }}">Total instances of element/attribute per publisher</a></li>
+                <li><a href="{{ static('data/csv/elements.csv') }}">Activities/Orgs with element/attribute per publisher</a></li>
+                <li><a href="{{ static('data/csv/elements_total.csv') }}">Total instances of element/attribute per publisher</a></li>
             </ul></p>
         </div>
     </div>
@@ -36,11 +36,11 @@
               <th>Total Instances of Element <a href="{{ stats_url }}/current/aggregated/elements_total.json">(J)</a></th>
             </tr></thead>
             <tbody>
-              {% for i, (element,publishers) in enumerate(current_stats.inverted_publisher.elements.items()) %}
-              {% if is_valid_element(element) %}
+              {% for i, (element,publishers) in func.enumerate(current_stats.inverted_publisher.elements.items()) %}
+              {% if func.is_valid_element_or_attribute(element) %}
               <tr>
-                <td class="break"><a href="{{ url_for('element', slug=slugs.element.by_i[i]) }}">{{ element }}</a></td>
-                <td><a href="{{ url_for('element', slug=slugs.element.by_i[i]) }}">{{ publishers|length }}</a></td>
+                <td class="break"><a href="{{ url('dash-exploringdata-elements-detail', args=[slugs.element.by_i[i]]) }}">{{ element }}</a></td>
+                <td><a href="{{ url('dash-exploringdata-elements-detail', args=[slugs.element.by_i[i]]) }}">{{ publishers|length }}</a></td>
                 <td>{{ current_stats.aggregated.elements[element] }}</td>
                 <td>{{ current_stats.aggregated.elements_total[element] }}</td>
               </tr>

--- a/dashboard/templates/org_ids.html
+++ b/dashboard/templates/org_ids.html
@@ -10,15 +10,15 @@
         <thead>
             <tr>
                 <th style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;" rowspan="2">Org Type</th>
-                {% include 'org_id_table_header.html' %}
+                {% include '_partials/org_id_table_header.html' %}
             </tr>
         </thead>
         <tbody>
             {% for slug in slugs.org_type.by_slug %}
             {% set transaction_stats = current_stats.aggregated[slug + '_transaction_stats'] %}
             <tr>
-                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url_for('org_type', slug=slug) }}" >{{ slug.replace('_org', '') | capitalize }}</a></td>
-                {% include 'org_id_table_cells.html' %}
+                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url('dash-exploringdata-orgtypes-detail', args=[slug]) }}" >{{ slug.replace('_org', '') | capitalize }}</a></td>
+                {% include '_partials/org_id_table_cells.html' %}
             </tr>
             {% endfor %}
         </tbody>

--- a/dashboard/templates/org_type.html
+++ b/dashboard/templates/org_type.html
@@ -20,17 +20,17 @@ Organisation Identifiers:  {{ slug.replace('_org', '') | capitalize }} Orgs
             <tr>
                 <th style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;" rowspan="2">Publisher Name</th>
                 <th style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;" rowspan="2">Publisher Registry Id</th>
-                {% include 'org_id_table_header.html' %}
+                {% include '_partials/org_id_table_header.html' %}
             </tr>
         </thead>
         <tbody>
             {% for publisher_title, publisher in publishers_ordered_by_title %}
-            {% set publisher_stats = get_publisher_stats(publisher) %}
+            {% set publisher_stats = func.get_publisher_stats(publisher) %}
             {% set transaction_stats = publisher_stats[slug + '_transaction_stats'] %}
             <tr>
-                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=publisher) }}#p_org_ids">{{ publisher_name[publisher] }}</a></td>
-                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url_for('publisher', publisher=publisher) }}#p_org_ids">{{ publisher }}</a></td>
-                {% include 'org_id_table_cells.html' %}
+                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}#p_org_ids">{{ publisher_name[publisher] }}</a></td>
+                <td style="border-left: 1px solid #ddd; border-right: 1px solid #ddd;"><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}#p_org_ids">{{ publisher }}</a></td>
+                {% include '_partials/org_id_table_cells.html' %}
             </tr>
             {% endfor %}
         </tbody>

--- a/dashboard/templates/traceability.html
+++ b/dashboard/templates/traceability.html
@@ -24,9 +24,9 @@
             </tr></thead>
             <tbody>
               {% for publisher_title,publisher in publishers_ordered_by_title %}
-              {% set publisher_stats = get_publisher_stats(publisher) %}
+              {% set publisher_stats = func.get_publisher_stats(publisher) %}
                   <tr>
-                      <td><a href="{{ url_for('publisher', publisher=publisher) }}">{{ publisher_title }}</a></td>
+                      <td><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher_title }}</a></td>
                       <td>
                         {%- if publisher_stats.traceable_activities_by_publisher_id -%}
                           {{ '{:,}'.format(publisher_stats.traceable_activities_by_publisher_id) }}

--- a/dashboard/ui/template_funcs.py
+++ b/dashboard/ui/template_funcs.py
@@ -6,3 +6,13 @@ def firstint(s):
         return 0
     m = re.search(r'\d+', s[0])
     return int(m.group(0))
+
+
+def get_codelist_values(codelist_values_for_element):
+    """Return a list of unique values present within a one-level nested dictionary.
+       Envisaged usage is to gather the codelist values used by each publisher, as in
+       stats/current/inverted-publisher/codelist_values_by_major_version.json
+       Input: Set of codelist values for a given element (listed by publisher), for example:
+              current_stats['inverted_publisher']['codelist_values_by_major_version']['1']['.//@xml:lang']
+    """
+    return list(set([y for x in codelist_values_for_element.items() for y in list(x[1].keys())]))

--- a/dashboard/ui/urls.py
+++ b/dashboard/ui/urls.py
@@ -53,8 +53,8 @@ urlpatterns = [
     # Exploring data pages.
     path('exploring-data/elements', ui.views.exploringdata_elements, name="dash-exploringdata-elements"),
     path('exploring-data/elements/<str:element>', ui.views.exploringdata_element_detail, name="dash-exploringdata-elements-detail"),
-    path('exploring-data/codelists', lambda x: None, name="dash-exploringdata-codelists"),
-    path('exploring-data/codelists/<int:major_version>/<str:attribute>', lambda x: None, name="dash-exploringdata-codelists-detail"),
+    path('exploring-data/codelists', ui.views.exploringdata_codelists, name="dash-exploringdata-codelists"),
+    path('exploring-data/codelists/<str:major_version>/<str:attribute>', ui.views.exploringdata_codelists_detail, name="dash-exploringdata-codelists-detail"),
     path('exploring-data/booleans', lambda x: None, name="dash-exploringdata-booleans"),
     path('exploring-data/dates', lambda x: None, name="dash-exploringdata-dates"),
     path('exploring-data/traceability', lambda x: None, name="dash-exploringdata-traceability"),

--- a/dashboard/ui/urls.py
+++ b/dashboard/ui/urls.py
@@ -55,9 +55,9 @@ urlpatterns = [
     path('exploring-data/elements/<str:element>', ui.views.exploringdata_element_detail, name="dash-exploringdata-elements-detail"),
     path('exploring-data/codelists', ui.views.exploringdata_codelists, name="dash-exploringdata-codelists"),
     path('exploring-data/codelists/<str:major_version>/<str:attribute>', ui.views.exploringdata_codelists_detail, name="dash-exploringdata-codelists-detail"),
-    path('exploring-data/booleans', lambda x: None, name="dash-exploringdata-booleans"),
-    path('exploring-data/dates', lambda x: None, name="dash-exploringdata-dates"),
-    path('exploring-data/traceability', lambda x: None, name="dash-exploringdata-traceability"),
+    path('exploring-data/booleans', ui.views.exploringdata_booleans, name="dash-exploringdata-booleans"),
+    path('exploring-data/dates', ui.views.exploringdata_dates, name="dash-exploringdata-dates"),
+    path('exploring-data/traceability', ui.views.exploringdata_traceability, name="dash-exploringdata-traceability"),
     path('exploring-data/organisation-identifiers', ui.views.exploringdata_orgids, name="dash-exploringdata-orgids"),
     path('exploring-data/organisation-type/<slug:org_type>', ui.views.exploringdata_orgtypes_detail, name="dash-exploringdata-orgtypes-detail"),
 

--- a/dashboard/ui/urls.py
+++ b/dashboard/ui/urls.py
@@ -58,8 +58,8 @@ urlpatterns = [
     path('exploring-data/booleans', lambda x: None, name="dash-exploringdata-booleans"),
     path('exploring-data/dates', lambda x: None, name="dash-exploringdata-dates"),
     path('exploring-data/traceability', lambda x: None, name="dash-exploringdata-traceability"),
-    path('exploring-data/organisation-identifiers', lambda x: None, name="dash-exploringdata-orgids"),
-    path('exploring-data/organisation-types/<slug:org_type>', lambda x: None, name="dash-exploringdata-orgtypes-detail"),
+    path('exploring-data/organisation-identifiers', ui.views.exploringdata_orgids, name="dash-exploringdata-orgids"),
+    path('exploring-data/organisation-type/<slug:org_type>', ui.views.exploringdata_orgtypes_detail, name="dash-exploringdata-orgtypes-detail"),
 
     # Publishing statistics pages.
     path('publishing-statistics/timeliness', lambda x: None, name="dash-publishingstats-timeliness"),

--- a/dashboard/ui/urls.py
+++ b/dashboard/ui/urls.py
@@ -51,8 +51,8 @@ urlpatterns = [
     path('data-quality/reporting-orgs', ui.views.dataquality_reportingorgs, name="dash-dataquality-reportingorgs"),
 
     # Exploring data pages.
-    path('exploring-data/elements', lambda x: None, name="dash-exploringdata-elements"),
-    path('exploring-data/elements/<str:element>', lambda x: None, name="dash-exploringdata-elements-detail"),
+    path('exploring-data/elements', ui.views.exploringdata_elements, name="dash-exploringdata-elements"),
+    path('exploring-data/elements/<str:element>', ui.views.exploringdata_element_detail, name="dash-exploringdata-elements-detail"),
     path('exploring-data/codelists', lambda x: None, name="dash-exploringdata-codelists"),
     path('exploring-data/codelists/<int:major_version>/<str:attribute>', lambda x: None, name="dash-exploringdata-codelists-detail"),
     path('exploring-data/booleans', lambda x: None, name="dash-exploringdata-booleans"),

--- a/dashboard/ui/views.py
+++ b/dashboard/ui/views.py
@@ -390,3 +390,18 @@ def exploringdata_codelists_detail(request, major_version=None, attribute=None):
     context["major_version"] = major_version
 
     return HttpResponse(template.render(context, request))
+
+
+def exploringdata_booleans(request):
+    template = loader.get_template("booleans.html")
+    return HttpResponse(template.render(_make_context("booleans"), request))
+
+
+def exploringdata_dates(request):
+    template = loader.get_template("dates.html")
+    return HttpResponse(template.render(_make_context("dates"), request))
+
+
+def exploringdata_traceability(request):
+    template = loader.get_template("traceability.html")
+    return HttpResponse(template.render(_make_context("traceability"), request))

--- a/dashboard/ui/views.py
+++ b/dashboard/ui/views.py
@@ -31,7 +31,7 @@ from data import (
     metadata,
     publisher_name,
     publishers_ordered_by_title,
-    is_valid_element,
+    is_valid_element_or_attribute,
     slugs)
 
 
@@ -150,8 +150,9 @@ def _make_context(page_name: str):
               "firstint": ui.template_funcs.firstint,
               "dataset_to_publisher": lambda x: dataset_to_publisher_dict.get(x, ""),
               "get_publisher_stats": get_publisher_stats,
-              "is_valid_element": is_valid_element,
-              "set": set
+              "is_valid_element_or_attribute": is_valid_element_or_attribute,
+              "set": set,
+              "enumerate": enumerate
               }
     )
     context["navigation_reverse"].update({k: k for k in text.navigation})
@@ -320,4 +321,22 @@ def dataquality_identifiers(request):
 def dataquality_reportingorgs(request):
     template = loader.get_template("reporting_orgs.html")
     context = _make_context("reporting_orgs")
+    return HttpResponse(template.render(context, request))
+
+
+#
+# Exploring data pages.
+#
+def exploringdata_elements(request):
+    template = loader.get_template("elements.html")
+    return HttpResponse(template.render(_make_context("elements"), request))
+
+
+def exploringdata_element_detail(request, element=None):
+    template = loader.get_template("element.html")
+    context = _make_context("elements")
+    i = slugs['element']['by_slug'][element]
+    context["element"] = list(current_stats['inverted_publisher']['elements'])[i]
+    context["publishers"] = list(current_stats['inverted_publisher']['elements'].values())[i]
+    context["element_or_attribute"] = 'attribute' if '@' in context["element"] else 'element'
     return HttpResponse(template.render(context, request))

--- a/dashboard/ui/views.py
+++ b/dashboard/ui/views.py
@@ -340,3 +340,16 @@ def exploringdata_element_detail(request, element=None):
     context["publishers"] = list(current_stats['inverted_publisher']['elements'].values())[i]
     context["element_or_attribute"] = 'attribute' if '@' in context["element"] else 'element'
     return HttpResponse(template.render(context, request))
+
+
+def exploringdata_orgids(request):
+    template = loader.get_template("org_ids.html")
+    return HttpResponse(template.render(_make_context("org_ids"), request))
+
+
+def exploringdata_orgtypes_detail(request, org_type=None):
+    assert org_type in slugs['org_type']['by_slug']
+    template = loader.get_template("org_type.html")
+    context = _make_context("org_ids")
+    context["slug"] = org_type
+    return HttpResponse(template.render(context, request))

--- a/dashboard/ui/views.py
+++ b/dashboard/ui/views.py
@@ -8,6 +8,7 @@
 import dateutil.parser
 import subprocess
 import json
+import collections
 
 from django.http import HttpResponse, Http404
 from django.template import loader
@@ -80,6 +81,21 @@ def _get_licenses_for_publisher(publisher_name):
         for package in ckan[publisher_name].values()])
 
 
+def dictinvert(d):
+    inv = collections.defaultdict(list)
+    for k, v in d.items():
+        inv[v].append(k)
+    return inv
+
+
+def nested_dictinvert(d):
+    inv = collections.defaultdict(lambda: collections.defaultdict(int))
+    for k, v in d.items():
+        for k2, v2 in v.items():
+            inv[k2][k] += v2
+    return inv
+
+
 def _make_context(page_name: str):
     """Make a basic context dictionary for a given page
     """
@@ -148,6 +164,7 @@ def _make_context(page_name: str):
         stats_commit_hash=STATS_COMMIT_HASH,
         func={"sorted": sorted,
               "firstint": ui.template_funcs.firstint,
+              "get_codelist_values": ui.template_funcs.get_codelist_values,
               "dataset_to_publisher": lambda x: dataset_to_publisher_dict.get(x, ""),
               "get_publisher_stats": get_publisher_stats,
               "is_valid_element_or_attribute": is_valid_element_or_attribute,
@@ -352,4 +369,24 @@ def exploringdata_orgtypes_detail(request, org_type=None):
     template = loader.get_template("org_type.html")
     context = _make_context("org_ids")
     context["slug"] = org_type
+    return HttpResponse(template.render(context, request))
+
+
+def exploringdata_codelists(request):
+    template = loader.get_template("codelists.html")
+    return HttpResponse(template.render(_make_context("codelists"), request))
+
+
+def exploringdata_codelists_detail(request, major_version=None, attribute=None):
+    template = loader.get_template("codelist.html")
+
+    context = _make_context("codelists")
+    i = slugs['codelist'][major_version]['by_slug'][attribute]
+    element = list(current_stats['inverted_publisher']['codelist_values_by_major_version'][major_version])[i]
+    values = nested_dictinvert(list(current_stats['inverted_publisher']['codelist_values_by_major_version'][major_version].values())[i])
+    context["element"] = element
+    context["values"] = values
+    context["reverse_codelist_mapping"] = {major_version: dictinvert(mapping) for major_version, mapping in codelist_mapping.items()}
+    context["major_version"] = major_version
+
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
This PR contains a set of commits that fully refactor the Dashboard exploring data pages.  Pages that require more extensive changes are refactored in separate commits.  Each commit completes the URL route, adds the view function(s), and refactors the relevant template(s).  Work on the codelists and elements pages needed changes in other files - most notably a change in the behaviour of `xmlschema` required a change in `data.py` for how we identified if elements/attributes were valid in a given schema.