### PR TITLE
get_stats.sh: Pull from the deployed copy of the merged codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Fetch stats
       run: |
         mkdir out
-        ./get_stats.sh
+        ./mock_stats_for_unit_tests.sh
     - name: Run tests
       run: pytest --cov .
     # - name: Coveralls

--- a/dashboard/data.py
+++ b/dashboard/data.py
@@ -203,7 +203,6 @@ ckan = json.load(open(filepaths.join_stats_path("ckan.json")), object_pairs_hook
 dataset_to_publisher_dict = {
     dataset: publisher for publisher, publisher_dict in ckan.items() for dataset in publisher_dict.keys()
 }
-metadata = json.load(open(filepaths.join_stats_path("metadata.json")), object_pairs_hook=OrderedDict)
 with open(filepaths.join_data_path("downloads/errors")) as fp:
     for line in fp:
         if line != ".\n":

--- a/dashboard/ui/views.py
+++ b/dashboard/ui/views.py
@@ -30,7 +30,6 @@ from data import (
     get_publisher_stats,
     github_issues,
     is_valid_element_or_attribute,
-    metadata,
     publisher_name,
     publishers_ordered_by_title,
     slugs,
@@ -113,6 +112,11 @@ def nested_dictinvert(d):
 
 def _make_context(page_name: str):
     """Make a basic context dictionary for a given page"""
+
+    with open(filepaths.join_stats_path("gitdate.json")) as fp:
+        date_time_data_str = max(json.load(fp).values())
+    date_time_data_obj = dateutil.parser.parse(date_time_data_str)
+
     context = dict(
         page=page_name,
         top_titles=text.top_titles,
@@ -166,9 +170,8 @@ def _make_context(page_name: str):
         github_issues=github_issues,
         MAJOR_VERSIONS=MAJOR_VERSIONS,
         expected_versions=vars.expected_versions,
-        metadata=metadata,
         slugs=slugs,
-        datetime_data=dateutil.parser.parse(metadata["created_at"]).strftime("%-d %B %Y (at %H:%M %Z)"),
+        datetime_data=date_time_data_obj.strftime("%-d %B %Y (at %H:%M %Z)"),
         current_year=datetime.datetime.now(datetime.UTC).year,
         stats_url="/stats",
         generated_url="/generated",

--- a/get_stats.sh
+++ b/get_stats.sh
@@ -1,3 +1,15 @@
-#!/bin/bash
+set -eux
+# ^ https://explainshell.com/explain?cmd=set+-eux
 
-git clone --depth=1 --quiet --branch gh-pages https://github.com/codeforIATI/IATI-Stats-public stats-calculated
+mkdir stats-calculated
+for f in ckan gitdate licenses; do
+    curl --compressed "https://dev.merged.dashboard.iatistandard.org/stats/${f}.json" > stats-calculated/${f}.json
+done
+
+cd stats-calculated
+wget "https://dev.merged.dashboard.iatistandard.org/stats/current.tar.gz" -O current.tar.gz
+wget "https://dev.merged.dashboard.iatistandard.org/stats/gitaggregate-dated.tar.gz" -O gitaggregate-dated.tar.gz
+wget "https://dev.merged.dashboard.iatistandard.org/stats/gitaggregate-publisher-dated.tar.gz" -O gitaggregate-publisher-dated.tar.gz
+tar -xf current.tar.gz
+tar -xf gitaggregate-dated.tar.gz
+tar -xf gitaggregate-publisher-dated.tar.gz

--- a/mock_stats_for_unit_tests.sh
+++ b/mock_stats_for_unit_tests.sh
@@ -1,0 +1,9 @@
+set -eux
+
+mkdir stats-calculated
+curl --compressed "https://dev.merged.dashboard.iatistandard.org/stats/ckan.json" > stats-calculated/ckan.json
+mkdir -p stats-calculated/current/aggregated-publisher
+mkdir -p stats-calculated/current/inverted-publisher
+for f in activities codelist_values_by_major_version elements; do
+    echo "{}" > stats-calculated/current/inverted-publisher/$f.json
+done


### PR DESCRIPTION
These files are rather large, so it's necessary to not run get_stats.sh in the CI. Instead I've added a mock shell script to set up the files it needs.

Our deploy also doesn't generate a metadata.json, so I've added a commit to switch to using gitdate.json for that instead.