### PR TITLE
Add custom dashboard panel class

### DIFF
--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -20,20 +20,8 @@ em {
   float: left;
 }
 
-.panel-heading {
-  clear: both;
-}
-
 .break {
   word-break:break-all;
-}
-
-.panel-body h4, .panel-body h5 {
-  margin-top: 24px;
-}
-
-.panel-body h4:first-of-type, .panel-body h5:first-of-type {
-  margin-top: 10px;
 }
 
 .table > tbody > tr > td,
@@ -86,10 +74,35 @@ a.popover-html:focus {
   outline: none;
 }
 
+/* Styles for the heading section of each page */
 .dashboard-page-heading {
   border-bottom: 1px solid var(--color-teal-80);
+  margin-bottom: 2rem;
 }
 
 .dashboard-page-heading__lead {
   font-size: 1.2rem;
+}
+
+/* Styles to implement panels to hold information */
+.dashboard-panel {
+  border: 1px solid var(--color-teal-20);
+  border-radius: 4px;
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-panel-heading {
+  background-color: var(--color-teal-90);
+  padding: 0.2rem 0.6rem;
+  justify-content: space-between;
+}
+
+.dashboard-panel-heading__title {
+  color: #fff;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.dashboard-panel-body {
+  margin: 1rem;
 }

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -157,6 +157,13 @@
           <li class="iati-breadcrumb-item iati-breadcrumb-item--current">
             <a aria-current="page" class="iati-breadcrumb-link">{{ top_titles['index'] }}</a>
           </li>
+        {% elif page=='registration_agencies' %}
+          <li class="iati-breadcrumb-item">
+            <a href="{{ url(page_view_names['index']) }}" class="iati-breadcrumb-link">{{ top_titles['index'] }}</a>
+          </li>
+          <li class="iati-breadcrumb-item iati-breadcrumb-item--current">
+            <a aria-current="page" class="iati-breadcrumb-link">Registration Agencies</a>
+          </li>
         {% else %}
           <li class="iati-breadcrumb-item">
             <a href="{{ url(page_view_names['index']) }}" class="iati-breadcrumb-link">{{ top_titles['index'] }}</a>

--- a/dashboard/templates/booleans.html
+++ b/dashboard/templates/booleans.html
@@ -2,15 +2,9 @@
 {% import '_partials/boxes.html' as boxes with context%}
 
 {% block content %}
-    <div class="row">
-      <div class="col-xs-12">
         <p>(<a href="{{ stats_url }}/current/inverted-publisher/boolean_values.json">This table as JSON</a>)</p>
-
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <p>List of values used by publishers for attributes that should be valid XML booleans (ie. <code>true</code>, <code>false</code>, <code>0</code> or <code>1</code>).</p>
-            {% include '_partials/tablesorter_instructions.html' %}
-          </div>
+        <p>List of values used by publishers for attributes that should be valid XML booleans (ie. <code>true</code>, <code>false</code>, <code>0</code> or <code>1</code>).</p>
+        {% include '_partials/tablesorter_instructions.html' %}
           <table class="table table-striped">
             <thead><tr><th>Element</th><th>Values</th><th>Publishers</th></tr></thead>
             <tbody>
@@ -25,9 +19,6 @@
               {% endfor %}
             </tbody>
           </table>
-        </div>
-      </div>
-    </div>
 {% endblock %}
 
 {% block tablesorteroptions %}{

--- a/dashboard/templates/codelist.html
+++ b/dashboard/templates/codelist.html
@@ -3,8 +3,8 @@
 
 {% block page_header %}
 <h1>Codelist values used for <code>{{ element }}</code></h1>
-<p class="lead">Who uses <code>{{ codelist_mapping[major_version].get(element) }}</code> in <code><a href="{{ element|xpath_to_url }}">{{ element }}</a></code>?</p>
-<p class="lead">(for files published to version {{ major_version }}.xx of the standard)</p>
+<p class="dashboard-page-heading__lead">Who uses <code>{{ codelist_mapping[major_version].get(element) }}</code> in <code><a href="{{ element|xpath_to_url }}">{{ element }}</a></code>?</p>
+<p class="dashboard-page-heading__lead">(for files published to version {{ major_version }}.xx of the standard)</p>
 <p style="float:right">(<a href="{{ stats_url }}/current/inverted-publisher/codelist_values.json">This page in JSON format</a>)</p>
 <p>Values should be on the <code><a href="{% if major_version=='2' %}http://iatistandard.org/codelists/{% else %}https://iatistandard.org/105/codelists/{% endif %}{{ codelist_mapping[major_version].get(element) }}/">{{ codelist_mapping[major_version].get(element) }}</a></code> codelist.</p>
 {% endblock %}
@@ -30,13 +30,12 @@
 
     <div class="row">
       <div class="col-md-6">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-              <h3 class="panel-title">On Codelist</h3>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+              <h2 class="dashboard-panel-heading__title">On Codelist</h2>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
             <p>Codes that are on the <code>{{ codelist_mapping[major_version].get(element) }}</code> codelist.</p>
-          </div>
           <table class="table table-striped">
             <thead><tr><th>Value</th><th>Name</th><th>Publishers</th></tr></thead>
             <tbody>
@@ -51,17 +50,17 @@
               {% endfor %}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
 
       <div class="col-md-6">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-              <h3 class="panel-title">Not On Codelist</h3>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+              <h2 class="dashboard-panel-heading__title">Not On Codelist</h2>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
               <p>Codes that are not on the <code>{{ codelist_mapping[major_version].get(element) }}</code> codelist.</p>
-          </div>
           <table class="table table-striped">
             <thead><tr><th>Value</th><th>Publishers</th></tr></thead>
             <tbody>
@@ -74,6 +73,7 @@
               {% endfor %}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/templates/codelists.html
+++ b/dashboard/templates/codelists.html
@@ -8,13 +8,14 @@
         {% include '_partials/tablesorter_instructions.html' %}
 
         {% for major_version in MAJOR_VERSIONS %}
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Codelists for version {{ major_version }}.xx</h3>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Codelists for version {{ major_version }}.xx</h2>
           </div>
           {% if major_version not in current_stats.inverted_publisher.codelist_values_by_major_version %}
               There are no publishers using {{ major_version }}.xx codelists yet.
           {% else %}
+          <div class="dashboard-panel-body">
           <table class="table table-striped">
             <thead><tr>
               <th>Element/Attribute on codelist</th>
@@ -41,6 +42,7 @@
               {% endfor %}
             </tbody>
           </table>
+          </div>
           {% endif %}
         </div>
         {% endfor %}

--- a/dashboard/templates/comprehensiveness.html
+++ b/dashboard/templates/comprehensiveness.html
@@ -16,19 +16,19 @@ Summary Table of Comprehensiveness Values
 
 
 {% block narrative_text %}
-	<h4>Overview</h4>
+	<h3>Overview</h3>
 	<p>To assess comprehensiveness, publication of selected elements of the standard have been aggregated into three sections. "Core" are the mandatory fields specified by version 2.01 of the Activity Standard. Financials cover publishing of both financial transactions and budgets. Value Added are optional elements of widespread benefit to users.</p>
 
-	<h4>Core Average</h4>
+	<h3>Core Average</h3>
 	<p>An average of the percentages assigned to the ten mandatory activity elements as specified on the Core tab.</p>
 	
-	<h4>Financials Average</h4>
+	<h3>Financials Average</h3>
 	<p>An average of the percentages assigned to four financial elements as specified on the Financials tab.</p>
 	
-	<h4>Value Added Average</h4>
+	<h3>Value Added Average</h3>
 	<p>An average of the percentages assigned to the ten most useful recommended (non-mandatory) elements as specified on the Value Added tab.</p>
 
-	<h4>Weighted Average</h4>
+	<h3>Weighted Average</h3>
 	<p>Twice the Core average plus the Financials average plus the Value-Added average, divided by 4.</p>
 {% endblock %}
 

--- a/dashboard/templates/comprehensiveness_base.html
+++ b/dashboard/templates/comprehensiveness_base.html
@@ -29,14 +29,14 @@
     </ul>
 
     {% block content %}
-    <div class="panel panel-default" id="h_table">
-    <div class="panel-heading">
-        <span class="pull-right"><a href="{{ generated_url }}/data/csv/comprehensiveness_{{ tab }}.csv">(This table as CSV)</a></span>
-        <h3 class="panel-title">{% block table_title %}Table of Comprehensiveness values{% endblock %}</h3>
+    <div class="dashboard-panel" id="h_table">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ generated_url }}/data/csv/comprehensiveness_{{ tab }}.csv" class="dashboard-panel-heading__title float-end">(This table as CSV)</a>
+        <h2 class="dashboard-panel-heading__title float-start">{% block table_title %}Table of Comprehensiveness values{% endblock %}</h2>
     </div>
 
     {% if self.heading_detail() %}
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         {% block heading_detail %}{% endblock %}
         {% include '_partials/tablesorter_instructions.html' %}
     </div>
@@ -77,11 +77,11 @@
 
 
     {% block narrative %}
-    <div class="panel panel-default" id="h_narrative">
-        <div class="panel-heading">
-            <h3 class="panel-title">Narrative</h3>
+    <div class="dashboard-panel" id="h_narrative">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Narrative</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             {% block narrative_text %}{% endblock %}
         </div>
     </div>
@@ -89,11 +89,11 @@
 
 
     {% block assessment %}
-    <div class="panel panel-default" id="h_assessment">
-        <div class="panel-heading">
-            <h3 class="panel-title">Assessment</h3>
+    <div class="dashboard-panel" id="h_assessment">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Assessment</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             {% block assessment_text %}{% endblock %}
         </div>
     </div>
@@ -101,11 +101,11 @@
 
 
     {% block exceptions %}
-    <div class="panel panel-default" id="h_exceptions">
-        <div class="panel-heading">
-            <h3 class="panel-title">Exceptions</h3>
+    <div class="dashboard-panel" id="h_exceptions">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Exceptions</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             {% block exceptions_text %}{% endblock %}
         </div>
     </div>
@@ -113,11 +113,11 @@
 
 
     {% block comparison %}
-    <div class="panel panel-default" id="h_comparison">
-        <div class="panel-heading">
-            <h3 class="panel-title">Comparison with original Global Partnership Indicator methodology</h3>
+    <div class="dashboard-panel" id="h_comparison">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Comparison with original Global Partnership Indicator methodology</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             {% block comparison_text %}
             <p>These tests are more targeted than the original methodology which merely checked for the existence of all fields irrespective of their importance.</p>
             {% endblock %}
@@ -126,11 +126,11 @@
     {% endblock %}
 
 
-    <div class="panel panel-default" id="h_pseudocode">
-    <div class="panel-heading">
-        <h3 class="panel-title">Pseudocode</h3>
+    <div class="dashboard-panel" id="h_pseudocode">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Pseudocode</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
 
     <p>For the purpose of this calculation, each <code>iati-activity</code> XML block is an activity.</p>
 

--- a/dashboard/templates/comprehensiveness_core.html
+++ b/dashboard/templates/comprehensiveness_core.html
@@ -15,40 +15,40 @@
 
 
 {% block narrative_text %}
-	<h4>Overview</h4>
+	<h3>Overview</h3>
 	<p>Version 2.01 introduced a more stringent approach to the way in which data can be validated (through the requirement that elements are published in a specified order) and as a result ten elements are mandatory for all activities under all conditions. This tab measures how comprehensively publishers are meeting these requirements, irrespective of whether they are using V2.01 or not.</p>
 
 	<p>Only <strong><em>current</em></strong> activities are assessed. A current activity is one with an activity status of implementing, a planned end date beyond today, or no end date.</p>
 
-	<h4>Details</h4>
-	<h5>Version</h5>
+	<h3>Details</h3>
+	<h4>Version</h4>
 	<p>Percentage of all current activities which contain a valid version number in the <code>&lt;iati-activities&gt;</code> file header element.</p>
 
-	<h5>Reporting Organisation</h5>
+	<h4>Reporting Organisation</h4>
 	<p>Percentage of all current activities which contain both a name and an identifier for the reporting organisation. (In future this will also check that the identifier contains a valid prefix identifying a registration agency.)</p>
 
-	<h5>IATI Identifier</h5>
+	<h4>IATI Identifier</h4>
 	<p>Percentage of all current activities that contain a valid activity identifier. This MUST be prefixed with either the identifier reported for the reporting organisation, or (if publishing at v2.xx) an identifier reported in the <code>&lt;other-identifier&gt;</code> element. (In future this will also check that each identifier is globally unique.)</p>
 
-	<h5>Participating Organisation</h5>
+	<h4>Participating Organisation</h4>
 	<p>Percentage of all current activities that contain a participating organisation of type <code>funding</code>.</p>
 
-	<h5>Title</h5>
+	<h4>Title</h4>
 	<p>Percentage of all current activities that contain a title.</p>
 
-	<h5>Description</h5>
+	<h4>Description</h4>
 	<p>Percentage of all current activities that contain a description.</p>
 
-	<h5>Status</h5>
+	<h4>Status</h4>
 	<p>Percentage of all current activities that contain a validly coded activity status.</p>
 
-	<h5>Activity Date</h5>
+	<h4>Activity Date</h4>
 	<p>Percentage of all current activities that contain a valid planned or actual start date.</p>
 
-	<h5>Sector</h5>
+	<h4>Sector</h4>
 	<p>Percentage of all current activities that EITHER contain at least one valid <code>activity-level</code> sector element OR all transactions contain a valid sector element. If multiple sectors are reported per vocabulary at activity level reported percentages must add up to 100% for the activity to be assessed as valid.</p>
 
-	<h5>Country or Region</h5>
+	<h4>Country or Region</h4>
 	<p>Percentage of all current activities that EITHER contain at least one valid activity level recipient country or region OR all transactions containing only one valid country or region. If more than one country and/or region is reported at activity then they must all contain percentages adding up to 100%.</p>
 {% endblock %}
 

--- a/dashboard/templates/comprehensiveness_financials.html
+++ b/dashboard/templates/comprehensiveness_financials.html
@@ -23,19 +23,19 @@ Table of Financial values
 
 
 {% block narrative_text %}
-	<h5>Transaction - Commitment</h5>
+	<h3>Transaction - Commitment</h3>
 	<p>For the data in the chosen hierarchy, the percentage of all current activities that contain at least one transaction of type <code>Commitment</code> or <code>Incoming Commitment</code>.  The hierarchy chosen for this calculation is the highest hierarchy that contains an above-defined commitment tranaction. Only one hierarchy is selected due in line with <a href="http://support.iatistandard.org/entries/40759343-General-rules-for-multi-level-reporting">stated IATI rules on multi-level reporting</a>.
 
-	<h5>Transaction - Disbursement or Expenditure</h5>
+	<h3>Transaction - Disbursement or Expenditure</h3>
 	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities that contain at least one transaction of type <code>Disbursement</code> or <code>Expenditure</code>.</p>
 
 
-	<h5>Transaction - Traceability</h5>
+	<h3>Transaction - Traceability</h3>
 	<p>For the data at the publishers' lowest hierarchy, the percentage of current activities containing a transaction of type <code>Incoming Funds</code>, <code>Incoming Commitment</code> or <code>Incoming Pledge</code> that also contain the IATI identifier for the funding organisation's activity. This links the funds disbursed by one organisation and received by another. (NB activities that do not contain incoming funds transactions are excluded from the calculation.) (In future the syntax of the provider-activity-id will also be validated.)</p>
 
 	<p>Donor publishers who list themselves within as a participating-org of either <code>1</code> (i.e. 'Funding') or <code>3</code> (i.e. 'Extending') AND who are not listed as type <code>4</code> (i.e. 'Implementing') will be given credit for traceability, as they are at the top of the funding chain.</p>
 
-	<h5>Budget</h5>
+	<h3>Budget</h3>
 	<p>For the hierarchy which contains the greatest number of budgets, the percentage of all current activities that contain at least one valid budget entry.  A valid budget entry must contain a valid <code>period-start</code> AND a valid <code>period-end</code> AND a valid <code>value</code> AND a valid <code>value-date</code> OR the activity has the <code>@budget-not-provided</code> attribute.</p>
 {% endblock %}
 

--- a/dashboard/templates/comprehensiveness_valueadded.html
+++ b/dashboard/templates/comprehensiveness_valueadded.html
@@ -21,31 +21,31 @@ Table of Value-Added values
 
 
 {% block narrative_text %}
-	<h5>Contacts</h5>
+	<h3>Contacts</h3>
 	<p>The percentage of all current activities that contain at least one contact email address.</p>
 
-	<h5>Location Details</h5>
+	<h3>Location Details</h3>
 	<p>The percentage of all current activities that contain at least one location name, location description, administrative area, or coordinates.</p>
 
-	<h5>Geographic Coordinates</h5>
+	<h3>Geographic Coordinates</h3>
 	<p>The importance of geocoded data is the reason why coordinates are assessed in addition to basic location details. The percentage of all current activities that contain at least one set of geographic coordinates.</p>
 
-	<h5>DAC Sectors</h5>
+	<h3>DAC Sectors</h3>
 	<p>Sector is a mandatory element and is assessed in the Core component. While it is not mandatory for publishers to utilise OECD DAC Sector/Purpose codes it is highly recommended that they do so as these codes are in widespread use and allow for comparison across activities. The percentage of all current activities that contain at least 1 valid DAC-CRS purpose code.</p>
 
-	<h5>Capital Spend</h5>
+	<h3>Capital Spend</h3>
 	<p>For sustainable planning it is useful for developing countries to know how project funding is split between capital and recurrent expenditure. The percentage of all current activities that contain a capital spend percentage. (N.B. that 0% is a valid entry.)</p>
 
-	<h5>Activity Documents</h5>
+	<h3>Activity Documents</h3>
 	<p>The percentage of all current activities that contain at least 1 document link.</p>
 
-	<h5>Aid Type</h5>
+	<h3>Aid Type</h3>
 	<p>The percentage of all current activities that contain details of the type of aid being supplied. This can be done at activity level using <code>default-aid-type</code>, or at transaction level using <code>aid-type</code>.</p>
 
-	<h5>Recipient Language</h5>
+	<h3>Recipient Language</h3>
 	<p>The percentage of activities targeted at only one <code>recipient-country</code> that contain <code>title</code> and <code>description</code> elements with at least one of the official languages spoken in that country.  These calculations are based on a <a href="https://github.com/IATI/IATI-Stats/blob/master/helpers/transparency_indicator/country_lang_map.csv">list of official languages within each country</a>.</p>
 
-	<h5>Result/Indicator</h5>
+	<h3>Result/Indicator</h3>
 	<p>The percentage of all current activities that contain at least one validly reported results indicator.</p>
 {% endblock %}
 

--- a/dashboard/templates/dates.html
+++ b/dashboard/templates/dates.html
@@ -2,11 +2,10 @@
 {% block content %}
     <div class="row">
       <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-heading"><h3 class="panel-title">Activity Dates</h3></div>
-          <div class="panel-body">
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading"><h2 class="dashboard-panel-heading__title">Activity Dates</h2></div>
+          <div class="dashboard-panel-body">
             {% include '_partials/tablesorter_instructions.html' %}
-          </div>
           <table class="table table-striped">
             <thead><tr>
               <th>Publisher</th>
@@ -28,6 +27,7 @@
               {% endfor %}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/templates/download.html
+++ b/dashboard/templates/download.html
@@ -8,15 +8,15 @@
 
     <div class="row">
       <div class="col-xs-12">
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading clearfix">
+            <h2 class="dashboard-panel-heading__title float-start">List of files that fail to download</h2>
+            <a class="dashboard-panel-heading__title float-end" href="{{ url('dash-dataquality-download-json') }}">This table as JSON</a>
+          </div>
+          <div class="dashboard-panel-body">
         <p><a href="https://gist.github.com/codeforIATIbot/f117c9be138aa94c9762d57affc51a64/revisions">History of Download Errors</a></p>
 
-        <p><a href="{{ url('dash-dataquality-download-json') }}">This table as JSON</a></p>
-
-        <div class="panel panel-default">
-          <div class="panel-body">
-              <p>List of files that fail to download.</p>
               {% include '_partials/tablesorter_instructions.html' %}
-          </div>
           <table class="table table-striped">
             <thead>
               <tr>
@@ -37,6 +37,7 @@
               {% endfor %}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/templates/element.html
+++ b/dashboard/templates/element.html
@@ -3,7 +3,7 @@
 
 {% block page_header %}
   <h1>Usage of <code>{{ element }}</code></h1>
-  <p class="lead">Who uses <code>{{ element }}</code>?</p>
+  <p class="dashboard-page-heading__lead">Who uses <code>{{ element }}</code>?</p>
   <p>Checking usage of <code><a href="{{ element|xpath_to_url }}">{{ element }}</a></code> across publishers, files and activities.</p>
 
   {% if element_or_attribute == 'attribute' %}
@@ -12,20 +12,16 @@
 {% endblock %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-xs-12">
-      <h2>Publishers</h2>
-
-      <p>(<a href="{{ stats_url }}/current/inverted-publisher/elements.json">In JSON format</a>)</p>
-    </div>
-  </div>
+  <h2>Publishers</h2>
+  <p>(<a href="{{ stats_url }}/current/inverted-publisher/elements.json">In JSON format</a>)</p>
 
   <div class="row">
     <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Publishing this {{ element_or_attribute }}</h3>
+      <div class="dashboard-panel">
+        <div class="dashboard-panel-heading">
+          <h3 class="dashboard-panel-heading__title">Publishing this {{ element_or_attribute }}</h3>
         </div>
+        <div class="dashboard-panel-body">
         <table class="table table-striped">
           <thead>
                 <td>Publisher</td>
@@ -52,14 +48,16 @@
             {% endfor %}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
 
     <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Not publishing this {{ element_or_attribute }}</h3>
+      <div class="dashboard-panel">
+        <div class="dashboard-panel-heading">
+          <h3 class="dashboard-panel-heading__title">Not publishing this {{ element_or_attribute }}</h3>
         </div>
+        <div class="dashboard-panel-body">
         <table class="table table-striped">
           <thead>
                 <td>Publisher</td>
@@ -80,15 +78,13 @@
             {% endfor %}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   </div>
 
 
-  <div class="row">
-    <div class="col-xs-12">
       <h2>Files</h2>
-      <div class="panel panel-default">
         <table class="table table-striped">
           <thead>
                 <td>Publisher</td>
@@ -108,7 +104,4 @@
             {% endfor %}
           </tbody>
         </table>
-      </div>
-    </div>
-  </div>
 {% endblock %}

--- a/dashboard/templates/elements.html
+++ b/dashboard/templates/elements.html
@@ -1,23 +1,10 @@
 {% extends 'base.html' %}
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
-    <div class="row">
-    <div class="col-md-6">
-    <div class="panel panel-default">
-        <div class="panel-body">
             <p>Download this data as CSV: <ul>
                 <li><a href="{{ generated_url }}/data/csv/elements.csv">Activities/Orgs with element/attribute per publisher</a></li>
                 <li><a href="{{ generated_url }}/data/csv/elements_total.csv">Total instances of element/attribute per publisher</a></li>
             </ul></p>
-        </div>
-    </div>
-    </div>
-    </div>
-
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-body">
             <p>Usage of IATI elements/attributes by:
             <ul>
             <li>Publishers: Total number of publishers that use this element/attribute (at least once)</li>
@@ -27,7 +14,6 @@
             </p>
             <p>Empty values for attributes are treated the same as if the attribute is not present.</p>
             {% include '_partials/tablesorter_instructions.html' %}
-          </div>
           <table class="table table-striped">
             <thead><tr>
               <th>Element/Attribute</th>
@@ -48,7 +34,5 @@
               {% endfor %}
             </tbody>
           </table>
-        </div>
-      </div>
-    </div>
+
 {% endblock %}

--- a/dashboard/templates/files.html
+++ b/dashboard/templates/files.html
@@ -10,11 +10,12 @@
     <div class="row">
       {{ boxes.box('Total File Size', current_stats.aggregated.file_size|filesizeformat, 'img/aggregate/file_size.png', 'file_size.json') }}
       <div class="col-md-6">
-        <div class="panel panel-default">
-        <div class="panel-heading">
-            <a href="{{ stats_url }}/current/aggregated/file_size_bins.json" style="float:right">(J)</a>
-            <h3 class="panel-title">File Sizes</h3>
+        <div class="dashboard-panel">
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ stats_url }}/current/aggregated/file_size_bins.json" class="dashboard-panel-heading__title float-end">(J)</a>
+            <h2 class="dashboard-panel-heading__title float-start">File Sizes</h2>
         </div>
+        <div class="dashboard-panel-body">
         <table class="table table-striped">
             <tbody>
             {% for bin,freq in func.sorted(current_stats.aggregated.file_size_bins.items(), key=func.firstint) %}
@@ -26,16 +27,20 @@
             </tbody>
         </table>
         </div>
+        </div>
       </div>
     </div>
 
     <div class="row">
       <div class="col-xs-12">
-        <div class="panel panel-default">
-        <div class="panel-body">
-            <p>Total file size by publisher</p>
-            {% include '_partials/tablesorter_instructions.html' %}
+        <div class="dashboard-panel">
+        <div class="dashboard-panel-heading">
+          <h2 class="dashboard-panel-heading__title">
+            Total file size by publisher
+          </h2>
         </div>
+        <div class="dashboard-panel-body">
+            {% include '_partials/tablesorter_instructions.html' %}
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -59,6 +64,8 @@
                 {% endfor %}
             </tbody>
         </table>
+                </div>
+
         </div>
       </div>
     </div>

--- a/dashboard/templates/forwardlooking.html
+++ b/dashboard/templates/forwardlooking.html
@@ -17,14 +17,14 @@
         <li><a href="#h_pseudocode">Pseudocode</a></li>
     </ul>
 
-    <div class="panel panel-default" id="h_table">
+    <div class="dashboard-panel" id="h_table">
 
-        <div class="panel-heading">
-            <span class="pull-right"><a href="{{ generated_url }}/data/csv/forwardlooking.csv">(This table as CSV)</a></span>
-            <h3 class="panel-title">Activities with Forward Looking Budget Allocations</h3>
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ generated_url }}/data/csv/forwardlooking.csv" class="dashboard-panel-heading__title float-end">(This table as CSV)</a>
+            <h2 class="dashboard-panel-heading__title float-start">Activities with Forward Looking Budget Allocations</h2>
         </div>
 
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>
                 The number of activities with budgets reported for each year is compared against the total number of activities current at the start of each year.  The first block shows the number of activities that are, or will be, current in this and the next two years. The second block shows how many of these activities contain a budget for the corresponding year. The third block expresses this as a percentage.
             </p>
@@ -39,7 +39,6 @@
                 <span style="background-color: #fcf8aa">Yellow flag</span>: Publisher currently publishing the 'budget not provided' attribute for some or all activities.<br/>
             </p>
             {% include '_partials/tablesorter_instructions.html' %}
-        </div>
 
         <table class="table table-striped" id="main_table">
             <thead>
@@ -85,15 +84,16 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </div>
 
 
 
-    <div class="panel panel-default" id="h_narrative">
-    <div class="panel-heading">
-        <h3 class="panel-title">Narrative</h3>
+    <div class="dashboard-panel" id="h_narrative">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Narrative</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>Developing countries have, since 2008, been asking their development partners to provide forward-looking data which can be used for both planning and budget preparation. While aggregated country-level budgets have a certain political value it is activity-level data that is of greatest benefit, and which this dimension attempts to assess.</p>
         <p>The standard asks publishers to break down their total commitment to an activity into annual or quarterly budgets - i.e. the sum of the reported budgets matches the sum of commitments. It is stressed that these budget breakdowns are indicative and are in no way binding.</p>
         <p>This assessment counts the number of current activities for this and the next two years that contain budgets. It is based on a number of assumptions:</p>
@@ -108,11 +108,11 @@
     </div>
 
 
-    <div class="panel panel-default" id="h_assesment">
-    <div class="panel-heading">
-        <h3 class="panel-title">Assessment</h3>
+    <div class="dashboard-panel" id="h_assesment">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Assessment</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>No separate assessment is provided as the percentage of current activities containing budgets for this and the next two years is the de facto assessment. No attempt is currently being made to turn these into a descriptive summary (as, for example, "Frequency = "Monthly"). The percentage for the middle year (i.e. 'next year') is of most relevance to developing countries.</p>
         <p>Activities with any <code>budget</code> elements that are also found to contain the <code>budget-not-provided</code> attribute will not receive a forward looking score.</p>
     </div>
@@ -120,27 +120,27 @@
 
 
 
-    <div class="panel panel-default" id="h_exceptions">
-    <div class="panel-heading">
-        <h3 class="panel-title">Exceptions</h3>
+    <div class="dashboard-panel" id="h_exceptions">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Exceptions</h2>
     </div>
-    <div class="panel-body">
-        <h4>Dashes</h4>
+    <div class="dashboard-panel-body">
+        <h3>Dashes</h3>
         <p>Where a percentage can not be calculated, because the denominator is zero, a dash is used.</p>
-        <h4>Red Flags</h4>
+        <h3>Red Flags</h3>
         <p>Publishers currently publishing forward looking budgets at more than one hierarchical level.</p>
-        <h4>Yellow Flags</h4>
+        <h3>Yellow Flags</h3>
         <p>Publishers currently publishing the 'budget not provided' attribute for some or all activities.</p>
     </div>
     </div>
 
 
 
-    <div class="panel panel-default" id="h_comparison">
-    <div class="panel-heading">
-        <h3 class="panel-title">Comparison with original Global Partnership Indicator methodology</h3>
+    <div class="dashboard-panel" id="h_comparison">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Comparison with original Global Partnership Indicator methodology</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>This methodology differs substantially from the original GP Indicator in two ways.</p>
         <ul>
         <li><strong><em>All</em> current</strong></em> activities are assessed, NOT only those containing Country Programmable Aid. CPA is calculated by the Forward Spending Survey by excluding activities based on a complex filtering of purpose codes, finance types and aid types. Firstly this is difficult to explain. Secondly the provision, or lack thereof, of forward looking data is not believed to be determined by CPA status. Thirdly, as a multi-stakeholder standard many IATI publishers, in particular implementing agencies, do not necessarily report CRS-specific fields.</li>
@@ -150,11 +150,11 @@
     </div>
 
 
-    <div class="panel panel-default" id="h_pseudocode">
-    <div class="panel-heading">
-        <h3 class="panel-title">Pseudocode</h3>
+    <div class="dashboard-panel" id="h_pseudocode">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Pseudocode</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
 
     <p>For the purpose of this calculation, each <code>iati-activity</code> XML block is an activity.</p>
 

--- a/dashboard/templates/humanitarian.html
+++ b/dashboard/templates/humanitarian.html
@@ -8,20 +8,19 @@
         <li><a href="#h_narrative">Narrative</a></li>
     </ul>
 
-    <div class="panel panel-default" id="h_table">
-        <div class="panel-heading">
-            <span class="pull-right"><a href="{{ generated_url }}/data/csv/humanitarian.csv">(This table as CSV)</a></span>
-            <h3 class="panel-title">Humanitarian</h3>
+    <div class="dashboard-panel" id="h_table">
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ generated_url }}/data/csv/humanitarian.csv" class="dashboard-panel-heading__title float-end">(This table as CSV)</a>
+            <h2 class="dashboard-panel-heading__title float-start">Humanitarian</h2>
         </div>
 
 
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>This table assesses the extent to which IATI publishers are reporting on humanitarian attributes.</p>
 
             <p>The statistics on this page do not form part of the <a href="{{ url('dash-publishingstats-summarystats') }}">Summary Statstics</a>.</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
-        </div>
 
         <table class="table table-striped" id="main_table">
             <thead>
@@ -50,37 +49,38 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </div>
 
 
-    <div class="panel panel-default" id="h_narrative">
-        <div class="panel-heading">
-            <h3 class="panel-title">Narrative</h3>
+    <div class="dashboard-panel" id="h_narrative">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Narrative</h2>
         </div>
-        <div class="panel-body">
-          <h5>Publisher</h5>
+        <div class="dashboard-panel-body">
+          <h3>Publisher</h3>
           <p>The name that this publisher self-defines as on the IATI Registry.</p>
 
-          <h5>Publisher Type</h5>
+          <h3>Publisher Type</h3>
           <p>The category that this publisher self-defines as on the IATI Registry.</p>
 
-          <h5>Number of Activities</h5>
+          <h3>Number of Activities</h3>
           <p>Total number of humanitarian activities.</p>
           <p>For activities published at IATI version 2.02 or higher, this is determined by the presence of either the <code>iati-activity/@humanitarian</code> attribute (set to <code>1</code> / <code>true</code>), at least one <code>iati-activity/transaction/@humanitarian</code> attribute (set to <code>1</code> / <code>true</code>).  Alternatively - and for activities published at any IATI version - this is determined by the use of DAC 5-digit sector codes between <code>72010</code> to <code>74020</code> inclusive, or DAC 3-digit sector codes <code>720</code>, <code>730</code> or <code>740</code>).</p>
 
-          <h5>Publishing Humanitarian?</h5>
+          <h3>Publishing Humanitarian?</h3>
           <p>If the number of activities is greater than 0, then this is set at 100. Otherwise, this is set at 0.</p>
 
-          <h5>Using Humanitarian Attribute?</h5>
+          <h3>Using Humanitarian Attribute?</h3>
           <p>The proportion of humanitarian activities that include a <code>iati-activity/@humanitarian</code> attribute (set to <code>1</code> / <code>true</code>), or at least one <code>iati-activity/transaction/@humanitarian</code> attribute (set to <code>1</code> / <code>true</code>) - proportion of the number of activities. Note this applies to activities published at IATI version 2.02 or higher.</p>
 
-          <h5>Appeal or Emergency Details</h5>
+          <h3>Appeal or Emergency Details</h3>
           <p>The proportion of humanitarian activities that include the <code>humanitarian-scope</code> element, The required attributes <code>humanitarian-scope/@type</code> and <code>humanitarian-scope/@code</code> must be present and contain non-empty data.</p>
 
-          <h5>Clusters</h5>
+          <h3>Clusters</h3>
           <p>The proportion of humanitarian activities that feature a sector code from the 'Humanitarian Global Clusters (Inter-Agency Standing Committee)' list — i.e. <code>iati-activity/sector/@vocabulary="10"</code>.</p>
 
-          <h5>Average</h5>
+          <h3>Average</h3>
           <p>The sum of the columns 'Publishing humanitarian?', 'Using humanitarian attribute?', 'Appeal or Emergency details' and 'Clusters', divided by 4.</p>
         </div>
     </div>

--- a/dashboard/templates/identifiers.html
+++ b/dashboard/templates/identifiers.html
@@ -3,20 +3,19 @@
 {% block content %}
     <div class="row">
       <div class="col-xs-12">
-        <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">
+        <div class="dashboard-panel">
+        <div class="dashboard-panel-heading">
+          <h2 class="dashboard-panel-heading__title">
             Count of duplicates, per publisher
-          </h3>
+          </h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
           <p>
             Duplicate identifiers: a count of the unique <code>iati-identifier</code> that are duplicated.
             Instances of duplicate identifiers: the total number of activities that contain a duplicate <code>iati-identifier</code>, within a publisher dataset.
             Example: two identifiers could be found as having duplicates.  Across the dataset, these duplicates could account for 200 activities.
           </p>
           {% include '_partials/tablesorter_instructions.html' %}
-        </div>
         <table class="table table-striped">
           <thead><tr>
             <th>Publisher</th>
@@ -36,6 +35,7 @@
             {% endfor %}
           </tbody>
         </table>
+        </div>
         </div>
       </div>
     </div>

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -8,12 +8,13 @@
 {% block lhs_column %}
 {{ super() }}
 
-<div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
+<div class="dashboard-panel">
+      <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">
             Overview
-        </h3>
+        </h2>
       </div>
+      <div class="dashboard-panel-body">
     <table class="table table-striped">
         <tbody>
             <tr>
@@ -120,6 +121,7 @@
             </tr>
         </body>
     </table>
+    </div>
 </div>
 
 {% endblock %}

--- a/dashboard/templates/license.html
+++ b/dashboard/templates/license.html
@@ -9,9 +9,6 @@
 
 {% block content %}
 
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="panel panel-default">
           <table class="table table-striped">
             <thead>
                 <tr>
@@ -28,7 +25,4 @@
                 {% endfor %}
             </tbody>
           </table>
-        </div>
-      </div>
-    </div>
 {% endblock %}

--- a/dashboard/templates/licenses.html
+++ b/dashboard/templates/licenses.html
@@ -3,11 +3,12 @@
 {% block content %}
     <div class="row">
       <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <p>Count of publishers per licences in use on the IATI Registry.</p>
-            {% include '_partials/tablesorter_instructions.html' %}
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Count of publishers per licences in use on the IATI Registry</h2>
           </div>
+          <div class="dashboard-panel-body">
+            {% include '_partials/tablesorter_instructions.html' %}
           <table class="table table-sm table-striped">
             <thead>
                 <tr>
@@ -28,6 +29,7 @@
                 {% endfor %}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/templates/org_ids.html
+++ b/dashboard/templates/org_ids.html
@@ -1,11 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="row">
-    <div class="col-xs-12">
-    <div class="panel panel-default">
-    <div class="panel-body">
         {% include '_partials/tablesorter_instructions.html' %}
-    </div>
     <table class="table table-striped">
         <thead>
             <tr>
@@ -23,8 +18,5 @@
             {% endfor %}
         </tbody>
     </table>
-    </div>
-    </div>
-    </div>
 
 {% endblock %}

--- a/dashboard/templates/org_type.html
+++ b/dashboard/templates/org_type.html
@@ -9,12 +9,7 @@ Organisation Identifiers:  {{ slug.replace('_org', '') | capitalize }} Orgs
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-    <div class="col-xs-12">
-    <div class="panel panel-default">
-    <div class="panel-body">
         {% include '_partials/tablesorter_instructions.html' %}
-    </div>
     <table class="table table-striped">
         <thead>
             <tr>
@@ -35,7 +30,4 @@ Organisation Identifiers:  {{ slug.replace('_org', '') | capitalize }} Orgs
             {% endfor %}
         </tbody>
     </table>
-    </div>
-    </div>
-    </div>
 {% endblock %}

--- a/dashboard/templates/organisation.html
+++ b/dashboard/templates/organisation.html
@@ -5,15 +5,14 @@
       {{ boxes.box('Publishers without an Organisation File', current_stats.aggregated.publisher_has_org_file.no, 'img/aggregate/publisher_has_org_file.png', 'publisher_has_org_file.json',
         description='Count of publishers without an organisation file, over time.') }}
       <div class="col-md-6">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              <span class="title-text">List of publishers without an Organisation File</span>
-            </h3>
-            <a href="{{ stats_url }}/current/inverted-publisher/publisher_has_org_file.json" style="float:right">(J)</a>
-            <br clear="all"/>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading clearfix">
+            <h2 class="dashboard-panel-heading__title float-start">
+              List of publishers without an Organisation File
+            </h2>
+            <a href="{{ stats_url }}/current/inverted-publisher/publisher_has_org_file.json" class="dashboard-panel-heading__title float-end">(J)</a>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
             <p>The following publishers do not have an organisation file listed on the IATI Registry.</p>
             <ul>
             {% for publisher in func.sorted(current_stats.inverted_publisher.publisher_has_org_file.no) %}

--- a/dashboard/templates/publisher.html
+++ b/dashboard/templates/publisher.html
@@ -149,32 +149,32 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             <div class="panel panel-default" id="p_validation">
               <!-- Default panel contents -->
               <div class="panel-heading"><h3 class="panel-title" id="list_fail_validation">Files Failing Validation</h3></div>
-              <!--<div class="panel-body">
-                <p>...</p>
-              </div>-->
-
-              <!-- List group -->
-              <ul class="list-group">
-                {% for dataset_name in current_stats.inverted_file_publisher[publisher].validation.fail.keys() %}
-                <li class="list-group-item">
-                  <div class="row">
-                    <div class="col-md-4 break">
-                      <a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a>
-                    </div>
-                    <div class="col-md-6 break">
-                      {% if publisher in ckan and dataset_name in ckan[publisher] %}
-                      <a href="{{ ckan[publisher][dataset_name].resource.url }}">{{ ckan[publisher][dataset_name].resource.url|url_to_filename }}</a>
-                      {% endif %}
-                    </div>
-                    <div class="col-md-2 break">
-                      {% if publisher in ckan and dataset_name in ckan[publisher] %}
-                      <a href="https://validator.iatistandard.org/report/{{ dataset_name }}">validator</a>
-                      {% endif %}
-                    </div>
-                  </div>
-                </li>
-                {% endfor %}
-              </ul>
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">Dataset name</th>
+                            <th scope="col">URL</th>
+                            <th scope="col">Validation</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for dataset_name in current_stats.inverted_file_publisher[publisher].validation.fail.keys() %}
+                        <tr>
+                            <td><a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a></td>
+                            <td>
+                                {% if publisher in ckan and dataset_name in ckan[publisher] %}
+                                    <a href="{{ ckan[publisher][dataset_name].resource.url }}">{{ ckan[publisher][dataset_name].resource.url|url_to_filename }}</a>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if publisher in ckan and dataset_name in ckan[publisher] %}
+                                  <a href="https://validator.iatistandard.org/report/{{ dataset_name }}">validator</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     {% endif %}

--- a/dashboard/templates/publisher.html
+++ b/dashboard/templates/publisher.html
@@ -155,8 +155,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
 
               <!-- List group -->
               <ul class="list-group">
-                {% for dataset in current_stats.inverted_file_publisher[publisher].validation.fail.keys() %}
-                {% with dataset_name = dataset[:-4] %}
+                {% for dataset_name in current_stats.inverted_file_publisher[publisher].validation.fail.keys() %}
                 <li class="list-group-item">
                   <div class="row">
                     <div class="col-md-4 break">
@@ -174,7 +173,6 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
                     </div>
                   </div>
                 </li>
-                {% endwith %}
                 {% endfor %}
               </ul>
             </div>
@@ -196,10 +194,10 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             </tr>
         </thead>
         <tbody>
-            {% for dataset, invalid in publisher_inverted.invalidxml.items() %}
+            {% for dataset_name, invalid in publisher_inverted.invalidxml.items() %}
             {% if invalid %}
             <tr>
-                <td><a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a></td>
+                <td><a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a></td>
             </tr>
             {% endif %}
             {% endfor %}
@@ -225,10 +223,10 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             </tr>
         </thead>
         <tbody>
-            {% for dataset, nonstandard in publisher_inverted.nonstandardroots.items() %}
+            {% for dataset_name, nonstandard in publisher_inverted.nonstandardroots.items() %}
             {% if nonstandard %}
             <tr>
-                <td><a href="http://iatiregistry.org/dataset/{{ dataset[:-4] }}">{{ dataset[:-4] }}</a></td>
+                <td><a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a></td>
             </tr>
             {% endif %}
             {% endfor %}
@@ -311,7 +309,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
         <tbody>
             {% for package, activities in publisher_inverted.activities.items() %}
             <tr>
-                <td class="break"><a href="http://iatiregistry.org/dataset/{{ package[:-4] }}">{{ package[:-4] }}</a></td>
+                <td class="break"><a href="http://iatiregistry.org/dataset/{{ package }}">{{ package }}</a></td>
                 <td>{{ activities }}</td>
                 <td>{{ current_stats.inverted_file.organisations.get(package) }}</td>
                 <td data-bytes="{{ current_stats.inverted_file.file_size.get(package) }}">{{ current_stats.inverted_file.file_size.get(package)|filesizeformat }}</td>

--- a/dashboard/templates/publisher.html
+++ b/dashboard/templates/publisher.html
@@ -12,9 +12,9 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
 {% block content %}
     <div class="row">
     <div class="col-md-6">
-    <div class="panel panel-default">
-        <div class="panel-heading"><h3 class="panel-title" id="list_fail_validation">Table of Contents</h3></div>
-        <div class="panel-body">
+    <div class="dashboard-panel">
+        <div class="dashboard-panel-heading"><h2 class="dashboard-panel-heading__title">Table of Contents</h2></div>
+        <div class="dashboard-panel-body">
             <ul>
                 <li><a href="#h_headlines">Headlines</a>
                 <li><a href="#h_dataquality">Data Quality</a>
@@ -49,7 +49,8 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
 
     <div class="row">
     <div class="col-md-6">
-    <div class="panel panel-default">
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <tbody>
             <tr>
@@ -119,6 +120,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
     </table>
     </div>
     </div>
+    </div>
     {{ boxes.box(
         'Activities', publisher_stats.activities, 'img/publishers/'+publisher+'_activities.png', publisher+'/activities.json', '', '-publisher') }} 
     </div>
@@ -146,9 +148,9 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
     {% if current_stats.inverted_file_publisher[publisher].validation.fail %}
         {% set data_quality_issue = true %}
         <div class="col-md-6">
-            <div class="panel panel-default" id="p_validation">
-              <!-- Default panel contents -->
-              <div class="panel-heading"><h3 class="panel-title" id="list_fail_validation">Files Failing Validation</h3></div>
+            <div class="dashboard-panel" id="p_validation">
+              <div class="dashboard-panel-heading"><h3 class="dashboard-panel-heading__title" id="list_fail_validation">Files Failing Validation</h3></div>
+              <div class="dashboard-panel-body">
                 <table>
                     <thead>
                         <tr>
@@ -176,17 +178,19 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
                     </tbody>
                 </table>
             </div>
+            </div>
         </div>
     {% endif %}
 
     {% if 1 in publisher_inverted.invalidxml.values() %}
     {% set data_quality_issue = true %}
     <div class="col-md-6">
-    <div class="panel panel-default" id="p_invalid">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/inverted-file-publisher/{{ publisher }}/invalidxml.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Files where XML is not well-formed</h3>
+    <div class="dashboard-panel" id="p_invalid">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/inverted-file-publisher/{{ publisher }}/invalidxml.json" class="dashboard-panel-heading__title float-end">(J)</a>
+        <h3 class="dashboard-panel-heading__title float-start">Files where XML is not well-formed</h3>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -205,17 +209,18 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
     </table>
     </div>
     </div>
+    </div>
     {% endif %}
 
     {% if 1 in publisher_inverted.nonstandardroots.values() %}
     {% set data_quality_issue = true %}
     <div class="col-md-6">
-    <div class="panel panel-default" id="p_nonstandardroots">
-    <table class="table table-striped">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/inverted-file-publisher/{{ publisher }}/nonstandardroots.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Files with non-standard roots</h3>
+    <div class="dashboard-panel" id="p_nonstandardroots">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/inverted-file-publisher/{{ publisher }}/nonstandardroots.json" class="dashboard-panel-heading__title float-end">(J)</a>
+        <h3 class="dashboard-panel-heading__title float-start">Files with non-standard roots</h3>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -232,6 +237,7 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             {% endfor %}
         </tbody>
     </table>
+    </div>
     </div>
     </div>
     {% endif %}
@@ -254,13 +260,14 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
     {% endif %}
     {% endmacro %}
 
-    <div class="panel panel-default">
-    <div class="panel-heading">
-        <h3 class="panel-title">Budgets</h3>
+    <div class="row">
+    <div class="col-xs-12">
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-heading">
+        <h3 class="dashboard-panel-heading__title">Budgets</h3>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>The below figures are calculated based on the data contained within the <code>&lt;budget&gt;</code> element for each reported activity. Original and revised elements are based on the value declared in the <code><a href="https://iatistandard.org/activity-standard/iati-activities/iati-activity/budget/">budget/@type</a></code> attribute. Where budgets fall across two calendar years, the month of the <code>&lt;period-end&gt;</code> date is used to determine annual groupings, with budgets for periods ending January-June added to the previous calendar year.</p>
-    </div>
     <table class="table table-striped">
         <thead>
             <tr>
@@ -288,14 +295,20 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
         </tbody>
     </table>
     </div>
+    </div>
+    </div>
+    </div>
 
 
     <h2 id="h_exploringdata">Exploring Data</h2>
 
-    <div class="panel panel-default" id="p_files">
-    <div class="panel-heading">
-        <h3 class="panel-title">Files</h3>
+    <div class="row">
+    <div class="col-xs-12">
+    <div class="dashboard-panel" id="p_files">
+    <div class="dashboard-panel-heading">
+        <h3 class="dashboard-panel-heading__title">Files</h3>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped exploring-data">
         <thead>
             <tr>
@@ -319,15 +332,20 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
         </tbody>
     </table>
     </div>
+    </div>
+    </div>
+    </div>
 
     {% for major_version in MAJOR_VERSIONS %}
     {% if major_version in publisher_stats.codelist_values_by_major_version %}
-    <div class="panel panel-default" id="p_codelists">
-    <table class="table table-striped">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/codelist_values.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Codelist Values (version {{ major_version }}.xx)</h3>
+    <div class="row">
+    <div class="col-xs-12">
+    <div class="dashboard-panel" id="p_codelists">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/codelist_values.json" class="float-end dashboard-panel-heading__title">(J)</a>
+        <h3 class="dashboard-panel-heading__title float-start">Codelist Values (version {{ major_version }}.xx)</h3>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -368,15 +386,20 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
         </tbody>
     </table>
     </div>
+    </div>
+    </div>
+    </div>
     {% endif %}
     {% endfor %}
 
-    <div class="panel panel-default" id="p_elements">
-    <table class="table table-striped">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/elements.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Elements and Attributes Published</h3>
+    <div class="row">
+    <div class="col-xs-12">
+    <div class="dashboard-panel" id="p_elements">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/aggregated-publisher/{{ publisher }}/elements.json" class="float-end dashboard-panel-heading__title">(J)</a>
+        <h3 class="float-start dashboard-panel-heading__title">Elements and Attributes Published</h3>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -400,12 +423,17 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
         </tbody>
     </table>
     </div>
-
-    <div class="panel panel-default" id="p_org_ids">
-    <table class="table table-striped">
-    <div class="panel-heading">
-        <h3 class="panel-title">Organisation Identifiers</h3>
     </div>
+    </div>
+    </div>
+
+    <div class="row">
+    <div class="col-xs-12">
+    <div class="dashboard-panel" id="p_org_ids">
+    <div class="dashboard-panel-heading">
+        <h3 class="dashboard-panel-heading__title">Organisation Identifiers</h3>
+    </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -425,6 +453,10 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
             {% endfor %}
         </tbody>
     </table>
+    </div>
+    </div>
+    </div>
+    </div>
     </div>
 
 {% endblock %}

--- a/dashboard/templates/publishers.html
+++ b/dashboard/templates/publishers.html
@@ -11,12 +11,14 @@
 
     <div class="row">
     <div class="col-xs-12">
-    <div class="panel panel-default">
-    <div class="panel-body">
-        <p style="float:right"><a href="{{ generated_url }}/data/csv/publishers.csv">(This table as CSV)</a></p>
-        <p>List of current active IATI publishers,  Click on the publisher name for more details.</p>
-        {% include '_partials/tablesorter_instructions.html' %}
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-heading clearfix">
+    <h2 class="dashboard-panel-heading__title float-start">List of current active IATI publishers</h2>
+    <a class="dashboard-panel-heading__title float-end" href="{{ generated_url }}/data/csv/publishers.csv">(This table as CSV)</a>
     </div>
+    <div class="dashboard-panel-body">
+        <p>Click on the publisher name for more details.</p>
+        {% include '_partials/tablesorter_instructions.html' %}
     <table class="table table-striped">
         <thead>
             <tr>
@@ -46,8 +48,9 @@
             {% endfor %}
         </tbody>
     </table>
-    </div>
     <p id="files_note">* Files is the sum of Activity Files <a href="{{ stats_url }}/current/inverted-publisher/activity_files.json">(J)</a> and Organisation Files <a href="{{ stats_url }}/current/inverted-publisher/organisation_files.json">(J)</a>.</p>
+        </div>
+    </div>
     </div>
     </div>
 {% endblock %}

--- a/dashboard/templates/registration_agencies.html
+++ b/dashboard/templates/registration_agencies.html
@@ -4,14 +4,15 @@
 
 <div class="row">
 <div class="col-xs-12">
-<p>Looking up reporting org identifiers against the registration agency codelist.</p>
 
-<div class="panel panel-default">
-<div class="panel-heading">
-  <h3 class="panel-title">
+<div class="dashboard-panel">
+<div class="dashboard-panel-heading">
+  <h2 class="dashboard-panel-heading__title">
     Registration Agencies in Data
-  </h3>
+  </h2>
 </div>
+<div class="dashboard-panel-body">
+<p>Looking up reporting org identifiers against the registration agency codelist.</p>
 <table class="table table-striped">
   <thead><tr>
     <th>Registration Agency</th>
@@ -29,16 +30,15 @@
   <tbody>
 </table>
 </div>
-
-<br/>
-<br/>
-
-<div class="panel panel-default">
-<div class="panel-heading">
-  <h3 class="panel-title">
-    Reporting Org Identifiers that don't match registration agencies
-  </h3>
 </div>
+
+<div class="dashboard-panel">
+<div class="dashboard-panel-heading">
+  <h2 class="dashboard-panel-heading__title">
+    Reporting Org Identifiers that don't match registration agencies
+  </h2>
+</div>
+<div class="dashboard-panel-body">
 <table class="table table-striped">
   <thead><tr>
     <th>Identifier</th>
@@ -59,6 +59,7 @@
 {% endfor %}
   </tbody>
 </table>
+</div>
 </div>
 </div>
 </div>

--- a/dashboard/templates/reporting_orgs.html
+++ b/dashboard/templates/reporting_orgs.html
@@ -3,16 +3,15 @@
 {% block content %}
 <div class="row">
 <div class="col-xs-12">
-    <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-heading">
+      <h2 class="dashboard-panel-heading__title">
         Inconsistent Reporting Org references
-      </h3>
+      </h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
       <p>List of Publishers where the reporting-org element does not match the reporting-org field in the IATI Registry.</p>
       {% include '_partials/tablesorter_instructions.html' %}
-    </div>
     <table class="table table-striped">
       <thead><tr>
         <th>Publisher</th>
@@ -35,6 +34,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
     </div>
 </div>
 </div>

--- a/dashboard/templates/section_index.html
+++ b/dashboard/templates/section_index.html
@@ -4,13 +4,13 @@
 
     <div class="col-md-6">
     {% block lhs_column %}
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
+    <div class="dashboard-panel">
+      <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">
             About
-        </h3>
+        </h2>
       </div>
-      <div class="panel-body">
+      <div class="dashboard-panel-body">
         {% block about %}
         {% endblock %}
       </div>
@@ -19,22 +19,24 @@
     </div>
 
     <div class="col-md-6">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
+    <div class="dashboard-panel">
+      <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">
             Contents
-        </h3>
+        </h2>
       </div>
-      <ul class="list-group">
+      <nav>
+      <ul>
       {% for item in (top_navigation if page=='index' else navigation[navigation_reverse[page]]) %}
-        <li class="list-group-item">
-        <h4><a href="{{ url(page_view_names[item]) }}">{{ page_titles[item] }}</a></h4>
+        <li>
+        <a href="{{ url(page_view_names[item]) }}">{{ page_titles[item] }}</a>
         {% if item in page_leads %}
           <p>{{ page_leads[item]|safe }}</p>
         {% endif %}
         </li>
       {% endfor %}
       </ul>
+      </nav>
     </div>
     </div>
 

--- a/dashboard/templates/summary_stats.html
+++ b/dashboard/templates/summary_stats.html
@@ -10,20 +10,19 @@
         <li><a href="#h_exceptions">Exceptions</a></li>
     </ul>
 
-    <div class="panel panel-default" id="h_table">
-        <div class="panel-heading">
-            <span class="pull-right"><a href="{{ generated_url }}/data/csv/summary_stats.csv">(This table as CSV)</a></span>
-            <h3 class="panel-title">Summary Statistics</h3>
+    <div class="dashboard-panel" id="h_table">
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ generated_url }}/data/csv/summary_stats.csv" class="dashboard-panel-heading__title float-end">(This table as CSV)</a>
+            <h2 class="dashboard-panel-heading__title float-start">Summary Statistics</h2>
         </div>
 
 
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>This table assesses <span style="text-decoration: underline;">all</span> IATI publishers by scoring three dimensions – Timeliness, Forward-looking and Comprehensiveness. The methodology is explained below the table and in the related Publisher Statistics pages. In summary:</p>
 
             <p><strong>{Score}</strong> = ( {Timeliness} + {Forward looking} + {Comprehensiveness} ) / 3 &nbsp;</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
-        </div>
 
         <table class="table table-striped" id="main_table">
             <thead>
@@ -46,15 +45,16 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </div>
 
 
-    <div class="panel panel-default" id="h_narrative">
-        <div class="panel-heading">
-            <h3 class="panel-title">Narrative</h3>
+    <div class="dashboard-panel" id="h_narrative">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Narrative</h2>
         </div>
-        <div class="panel-body">
-            <h4>Timeliness</h5>
+        <div class="dashboard-panel-body">
+            <h3>Timeliness</h3>
             <p>This is calculated by scoring the assessments made on the <a href="{{ url('dash-publishingstats-timeliness') }}">
                frequency</a> and <a href="{{ url('dash-publishingstats-timeliness-timelag') }}">timelag</a> pages on a scale of
                0 to 4 (as below), dividing the sum of the two scores by 8, and expressing the result as
@@ -116,17 +116,17 @@
             </table>
 
 
-            <h4>Forward looking</h4>
+            <h3>Forward looking</h3>
             <p>The average percentage of current activities with budgets for each of the years {{ current_year }} - {{ current_year + 2 }}.
                The component values and a detailed methodology are displayed on the <a href="{{ url('dash-publishingstats-forwardlooking') }}">forward looking</a> page.
             </p>
 
 
-            <h4>Comprehensiveness</h4>
+            <h3>Comprehensiveness</h3>
             <p>The average of <a href="{{ url('dash-publishingstats-comprehensiveness') }}">comprehensiveness</a> averages for core, financials and value-added. The core average has a double-weighting.</p>
 
 
-            <h4>Score</h4>
+            <h3>Score</h3>
             <p>The mean average of the three values above.</p>
 
             <p><strong>{Score}</strong> = ( {Timeliness} + {Forward looking} + {Comprehensiveness} ) / 3</p>
@@ -135,12 +135,12 @@
     </div>
 
 
-    <div class="panel panel-default" id="h_exceptions">
-        <div class="panel-heading">
-            <h3 class="panel-title">Exceptions</h3>
+    <div class="dashboard-panel" id="h_exceptions">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Exceptions</h2>
         </div>
-        <div class="panel-body">
-            <h5>Secondary reporters</h5>
+        <div class="dashboard-panel-body">
+            <h3>Secondary reporters</h3>
             <p>Publishers who publish all of their activities as a secondary reporter do not appear in this table.
             {% if summary_stats.secondary_publishers|length > 0 %}
             Therefore, a total of {{ summary_stats.secondary_publishers|length }} publishers have been excluded in this regard:

--- a/dashboard/templates/timeliness.html
+++ b/dashboard/templates/timeliness.html
@@ -4,16 +4,14 @@
 {% import '_partials/boxes.html' as boxes with context %}
 
 {% block content %}
-    <div class="panel panel-default" id="h_table">
+    <div class="dashboard-panel" id="h_table">
 
-        <div class="panel-heading">
-            <span class="pull-right"><a href="{{ generated_url }}/data/csv/timeliness_frequency.csv">(This table as CSV)</a></span>
-            <h3 class="panel-title">Table of Frequency assessments</h3>
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ generated_url }}/data/csv/timeliness_frequency.csv" class="float-end dashboard-panel-heading__title">(This table as CSV)</a>
+            <h2 class="float-start dashboard-panel-heading__title">Table of Frequency assessments</h2>
         </div>
 
-
-
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>This table seeks to measure how often a publisher updates their data. As transactions are the most numerous element reported in IATI the adopted methodology assumes that a publisher has updated their data if a transaction with a more recent transaction date than previously published is detected across the publisher's entire portfolio. </p>
 
             <p>The table records the number of days in each of the last twelve months on which the most recently recorded transaction date was observed to have changed. (The current month is also displayed for informational purposes, but is not used in the assessment.) </p>
@@ -23,7 +21,6 @@
             <span style="background-color: #fcf8aa">Yellow flag</span>: Publisher not currently publishing future transaction dates, but did report future transactions at some point in the last twelve calendar months (See exceptions).</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
-        </div>
 
         <table class="table table-striped" id="main_table">
             <thead>
@@ -57,13 +54,15 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </div>
 
 
-    <div class="panel panel-default" id="h_summary">
-    <div class="panel-heading">
-        <h3 class="panel-title">Summary of Publisher Performance</h3>
+    <div class="dashboard-panel" id="h_summary">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Summary of Publisher Performance</h2>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -87,14 +86,15 @@
             </tr>
     </table>
     </div>
-
-
-
-    <div class="panel panel-default" id="h_narrative">
-    <div class="panel-heading">
-        <h3 class="panel-title">Narrative</h3>
     </div>
-    <div class="panel-body">
+
+
+
+    <div class="dashboard-panel" id="h_narrative">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Narrative</h2>
+    </div>
+    <div class="dashboard-panel-body">
         <p>The frequency statistics attempt to assess how often any part of a publisher's data is substantively updated.</p>
 
         <p>For the purposes of these statistics an update is assumed to have taken place on any given day when the most recently recorded transaction date across a publisher's entire portfolio is observed to have changed to a more recent date. This approach has been adopted as transactions are the most numerous and most frequently updated elements in the reporting of activities.</p>
@@ -105,15 +105,15 @@
 
 
 
-    <div class="panel panel-default" id="h_assesment">
-    <div class="panel-heading">
-        <h3 class="panel-title">Assessment</h3>
+    <div class="dashboard-panel" id="h_assesment">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Assessment</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>To assess these statistics one also has to take into account how long a publisher has been publishing to IATI. This is calculated based on when a publisher first appeared in the statistical snapshot.</p>
         <p>These statistics are then assessed as follows:</p>
 
-        <h4>For publishers of 1 year or more</h4>
+        <h3>For publishers of 1 year or more</h3>
         <table class="table table-striped">
         <thead>
         <tr>
@@ -145,7 +145,7 @@
         </tbody>
         </table>
 
-        <h4>For publishers of six months or more</h4>
+        <h3>For publishers of six months or more</h3>
         <table class="table table-striped">
         <thead>
         <tr>
@@ -169,7 +169,7 @@
         </tbody>
         </table>
 
-        <h4>For publishers of three months or more</h4>
+        <h3>For publishers of three months or more</h3>
         <table class="table table-striped">
         <thead>
         <tr>
@@ -189,7 +189,7 @@
         </tbody>
         </table>
 
-        <h4>For publishers of less than 3 months</h4>
+        <h3>For publishers of less than 3 months</h3>
         <table class="table table-striped">
         <thead>
         <tr>
@@ -209,11 +209,11 @@
 
 
 
-    <div class="panel panel-default" id="h_exceptions">
-        <div class="panel-heading">
-            <h3 class="panel-title">Exceptions</h3>
+    <div class="dashboard-panel" id="h_exceptions">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Exceptions</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>Future transaction dates disrupt these statistics. For example a publisher might today report a transaction date for each month for the next year and never refresh their data. Over the next year, as each of these future dates move into the past, the statistics would incorrectly give the publisher a frequency assessment of monthly, even though they did not refresh their data.</p>
 
             <p><strong>Future transaction dates may affect the assessments on this page</strong>. Publishers who currently have future transaction dates have a <span style="background-color: #f2aaaa">red flag</span> next to their assessment. A <span style="background-color: #fcf8aa">yellow flag</span> indicates that although a publisher does not currently have future transactions, they did report future transactions at some point over the last twelve calendar months.</p>
@@ -224,11 +224,11 @@
 
 
 
-    <div class="panel panel-default" id="h_comparison">
-    <div class="panel-heading">
-        <h3 class="panel-title">Comparison with original Global Partnership Indicator methodology</h3>
+    <div class="dashboard-panel" id="h_comparison">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Comparison with original Global Partnership Indicator methodology</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>This methodology is substantially different.
 
         <p>In the original Indicator methodology the IATI Registry log dates were analysed to assess when updates had been made. This approach was flawed as the Registry logs record any change, no matter how trivial. A spelling correction, for example, would count as an update. Similarly if a publisher's file was inaccessible, its reappearance would count as an update.</p>
@@ -237,11 +237,11 @@
 
 
 
-    <div class="panel panel-default" id="h_pseudocode">
-    <div class="panel-heading">
-        <h3 class="panel-title">Pseudocode</h3>
+    <div class="dashboard-panel" id="h_pseudocode">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Pseudocode</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>To get a count of updates by calendar month (for a given publisher):</p>
 <pre>
 For data captured each day over the past year

--- a/dashboard/templates/timeliness_timelag.html
+++ b/dashboard/templates/timeliness_timelag.html
@@ -4,15 +4,15 @@
 {% import '_partials/boxes.html' as boxes with context %}
 
 {% block content %}
-    <div class="panel panel-default" id="h_table">
+    <div class="dashboard-panel" id="h_table">
 
-        <div class="panel-heading">
-            <span class="pull-right"><a href="{{ generated_url }}/data/csv/timeliness_timelag.csv">(This table as CSV)</a></span>
-            <h3 class="panel-title">Table of Time lag assessments</h3>
+        <div class="dashboard-panel-heading clearfix">
+            <a href="{{ generated_url }}/data/csv/timeliness_timelag.csv" class="dashboard-panel-heading__title float-end">(This table as CSV)</a>
+            <h2 class="float-start dashboard-panel-heading__title">Table of Time lag assessments</h2>
         </div>
 
 
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>The time-lag statistics attempt to assess how up to date the data is <strong><em>at the point that it is refreshed</em></strong>. For instance a publisher may refresh their data monthly, but the refreshed data is in fact three months old. Alternatively a publisher may only refresh their data once a year, but when they do it contains current data that is less than one month out of date. Transactions are the most numerous and most regularly refreshed elements in reported IATI activities and they are therefore used to make this assessment. The table of statistics shows the number of transaction dates reported in each of the last twelve calendar months. The current month is shown for informational purposes, but excluded from the assessment.</p>
 
             <p><strong>Key:</strong><br/>
@@ -20,8 +20,6 @@
             <span style="background-color: #fcf8aa">Yellow flag</span>: Publisher not currently publishing future transaction dates, but did report future transactions at some point in the last twelve calendar months (See exceptions).</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
-        </div>
-
 
         <table class="table table-striped" id="main_table">
             <thead>
@@ -53,15 +51,17 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </div>
 
 
 
 
-    <div class="panel panel-default" id="h_summary">
-        <div class="panel-heading">
-            <h3 class="panel-title">Summary of Publisher Performance</h3>
+    <div class="dashboard-panel" id="h_summary">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Summary of Publisher Performance</h2>
         </div>
+        <div class="dashboard-panel-body">
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -84,16 +84,17 @@
                     <td>{{ summary.values()|sum }}</td>
                 </tr>
         </table>
+        </div>
     </div>
 
 
 
 
-    <div class="panel panel-default" id="h_narrative">
-        <div class="panel-heading">
-            <h3 class="panel-title">Narrative</h3>
+    <div class="dashboard-panel" id="h_narrative">
+        <div class="dashboard-panel-heading">
+            <h2 class="dashboard-panel-heading__title">Narrative</h2>
         </div>
-        <div class="panel-body">
+        <div class="dashboard-panel-body">
             <p>The time-lag statistics attempt to assess how up to date the data is <strong><em>at the point that it is refreshed</em></strong>. For instance a publisher may refresh their data monthly, but the refreshed data is in fact three months old. Alternatively a publisher may only refresh their data once a year, but when they do it contains current data that is less than one month out of date.</p>
 
             <p>Transactions are the most numerous and most regularly refreshed elements in reported IATI activities and they are therefore used to make this assessment.</p>
@@ -106,11 +107,11 @@
 
 
 
-    <div class="panel panel-default" id="h_assesment">
-    <div class="panel-heading">
-        <h3 class="panel-title">Assessment</h3>
+    <div class="dashboard-panel" id="h_assesment">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Assessment</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>These statistics are assessed as follows:</p>
         <table class="table table-striped">
         <thead>
@@ -148,11 +149,11 @@
 
 
 
-    <div class="panel panel-default" id="h_exceptions">
-    <div class="panel-heading">
-        <h3 class="panel-title">Exceptions</h3>
+    <div class="dashboard-panel" id="h_exceptions">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Exceptions</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>Future transaction dates disrupt these statistics. For example a publisher might today report a transaction date for each month for the next year and never refresh their data. Over the next year, as each of these future dates move into the past, the statistics would incorrectly give the publisher a time-lag assessment of one month in arrears, even though they did not refresh their data.</p>
 
         <p><strong>Future transaction dates may affect the assessments on this page</strong>. Publishers who currently have future transaction dates have a <span style="background-color: #f2aaaa">red flag</span> next to their assessment. A <span style="background-color: #fcf8aa">yellow flag</span> indicates that although a publisher does not currently have future transactions, they did report future transactions at some point over the last twelve calendar months.</p>
@@ -164,22 +165,22 @@
 
 
 
-    <div class="panel panel-default" id="h_comparison">
-    <div class="panel-heading">
-        <h3 class="panel-title">Comparison with orginal Global Partnership Indicator methodology</h3>
+    <div class="dashboard-panel" id="h_comparison">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Comparison with orginal Global Partnership Indicator methodology</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>No change.</p>
     </div>
     </div>
 
 
 
-    <div class="panel panel-default" id="h_pseudocode">
-    <div class="panel-heading">
-        <h3 class="panel-title">Pseudocode</h3>
+    <div class="dashboard-panel" id="h_pseudocode">
+    <div class="dashboard-panel-heading">
+        <h2 class="dashboard-panel-heading__title">Pseudocode</h2>
     </div>
-    <div class="panel-body">
+    <div class="dashboard-panel-body">
         <p>To get a count of transactions by calendar month (for a given publisher):</p>
 <pre>
 Using most recently captured data.

--- a/dashboard/templates/traceability.html
+++ b/dashboard/templates/traceability.html
@@ -1,17 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-heading"><h3 class="panel-title">Traceability</h3></div>
-          <div class="panel-body">
             <p>This page calculates the percentage of publishers’ spending that is traceable.</p>
             <p>This has been assessed based on other publishers’ activities that reference the activity in <code>transaction/provider-org/@provider-activity-id</code>. If an activity is referenced, all of its spending is counted.</p>
             <p>Two calculations are made on this page: Counting the activities, and adding up all of the activities’ spend.</p>
             <p>Spend is the sum of commitments and disbursements.</p>
 
             {% include '_partials/tablesorter_instructions.html' %}
-          </div>
           <table class="table table-striped">
             <thead><tr>
               <th>Publisher</th>
@@ -73,7 +67,5 @@
               {% endfor %}
             </tbody>
           </table>
-        </div>
-      </div>
-    </div>
+
 {% endblock %}

--- a/dashboard/templates/validation.html
+++ b/dashboard/templates/validation.html
@@ -29,28 +29,34 @@
             <p>...</p>
           </div>-->
 
-          <!-- List group -->
-          <ul class="list-group">
-            {% for dataset_name in datasets.keys() %}
-            <li class="list-group-item">
-              <div class="row">
-                <div class="col-md-4 break">
-                  <a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a>
-                </div>
-                <div class="col-md-6 break">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Dataset</th>
+                <th scope="col">URL</th>
+                <th scope="col">Validator report</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for dataset in datasets.keys() %}
+            {% with dataset_name=dataset %}
+              <tr>
+                <td><a href="http://iatiregistry.org/dataset/{{ dataset_name }}">{{ dataset_name }}</a></td>
+                <td>
                   {% if publisher in ckan and dataset_name in ckan[publisher] %}
                   <a href="{{ ckan[publisher][dataset_name].resource.url }}">{{ ckan[publisher][dataset_name].resource.url|url_to_filename }}</a>
                   {% endif %}
-                </div>
-                <div class="col-md-2 break">
+                </td>
+                <td>
                    {% if publisher in ckan and dataset_name in ckan[publisher] %}
                    <a href="https://validator.iatistandard.org/report/{{ dataset_name }}">validator</a>
                    {% endif %}
-                </div>
-              </div>
-            </li>
+                </td>
+              </tr>
+            {% endwith %}
             {% endfor %}
-          </ul>
+            </tbody>
+          </table>
         </div>
         {% endif %}
         {% endwith %}

--- a/dashboard/templates/validation.html
+++ b/dashboard/templates/validation.html
@@ -8,27 +8,21 @@
         description='Count of publishers that have at least one invalid file, over time') }}
     </div>
 
-    <div class="row">
-    <div class="col-xs-12">
     <h2>Breakdown By Publisher</h2>
-    </div>
-    </div>
 
     <div class="row">
     <div class="col-md-6">
-
-        <h3>List of files that fail validation, grouped by publisher</h3>
-
+      <div class="dashboard-panel">
+      <div class="dashboard-panel-heading">
+        <h3 class="dashboard-panel-heading__title">List of files that fail validation, grouped by publisher</h3>
+      </div>
+      <div class="dashboard-panel-body">
+        <div class="iati-card-gallery">
     {% for publisher in current_stats.inverted_file_publisher %}
         {% with datasets = current_stats.inverted_file_publisher[publisher].validation.get('fail', {}) %}
         {% if datasets %}
-        <div class="panel panel-default">
-          <!-- Default panel contents -->
-          <div class="panel-heading"><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}" id="list_{{ publisher }}">{{ publisher_name[publisher ] }}</a> ({{ datasets|length }})</div>
-          <!--<div class="panel-body">
-            <p>...</p>
-          </div>-->
-
+        <div class="iati-card">
+          <h4><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}" id="list_{{ publisher }}">{{ publisher_name[publisher ] }}</a> ({{ datasets|length }})</h4>
           <table>
             <thead>
               <tr>
@@ -57,17 +51,21 @@
             {% endfor %}
             </tbody>
           </table>
-        </div>
+        </div> <!-- end of card -->
         {% endif %}
         {% endwith %}
     {% endfor %}
-    </div>
+        </div> <!-- end of iati card gallery -->
+      </div> <!-- end of panel body -->
+    </div> <!-- end of panel -->
+    </div> <!-- end of column -->
 
     <div class="col-md-6">
-
-      <h3>Count of files that fail validation, per publisher.</h3>
-
-      <div class="panel panel-default">
+      <div class="dashboard-panel">
+      <div class="dashboard-panel-heading">
+        <h3 class="dashboard-panel-heading__title">Count of files that fail validation, per publisher</h3>
+      </div>
+      <div class="dashboard-panel-body">
         <table class="table table-striped">
           <thead><tr>
             <th>Publisher <a href="{{ stats_url }}/current/inverted-publisher/validation.json">(J)</a></th>
@@ -84,7 +82,8 @@
             {% endfor %}
           </tbody>
         </table>
-      </div>
-    </div>
-    </div>
+      </div> <!-- end of panel body -->
+    </div> <!-- end of panel -->
+    </div> <!-- end of column -->
+  </div> <!-- end of row -->
 {% endblock %}

--- a/dashboard/templates/validation.html
+++ b/dashboard/templates/validation.html
@@ -31,8 +31,7 @@
 
           <!-- List group -->
           <ul class="list-group">
-            {% for dataset in datasets.keys() %}
-            {% with dataset_name=dataset[:-4] %}
+            {% for dataset_name in datasets.keys() %}
             <li class="list-group-item">
               <div class="row">
                 <div class="col-md-4 break">
@@ -50,7 +49,6 @@
                 </div>
               </div>
             </li>
-            {% endwith %}
             {% endfor %}
           </ul>
         </div>

--- a/dashboard/templates/versions.html
+++ b/dashboard/templates/versions.html
@@ -13,13 +13,12 @@
     </div>
 
     {% if 'true' in current_stats.aggregated.version_mismatch %}
+    <h2>Inconsistent versions</h2>
+    <p>Files where the iati-activities/@version does not match iati-activity/@version</p>
     <div class="row">
     <div class="col-xs-12">
-    <h2>Inconsistent versions</h2>
-
-    <p>Files where the iati-activities/@version does not match iati-activity/@version</p>
-
-      <div class="panel panel-default">
+      <div class="dashboard-panel">
+      <div class="dashboard-panel-body">
         <table class="table table-striped">
           <thead>
                 <td>Publisher</td>
@@ -42,29 +41,28 @@
       </div>
     </div>
     </div>
+    </div>
     {% endif %}
 
-    <div class="row">
-    <div class="col-xs-12">
     <h2>Publishers by version</h2>
-
     <p>(<a href="{{ stats_url }}/current/inverted-publisher/versions.json">In JSON format</a>)</p>
-    </div>
-    </div>
-
     <div class="row">
       <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Expected versions</h3>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+            <h3 class="dashboard-panel-heading__title">Expected versions</h3>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
           <p>Listing of publishers per IATI version. Click on any publisher name for more information.</p>
-          <div class="row">
+          <div class="iati-card-gallery">
+
             {% for version, publishers in current_stats.inverted_publisher.versions.items() %}
             {% if version in expected_versions %}
-            <div class="col-md-4">
+            <div class="iati-card">
+              <h4>
               <code>{{ version|replace(' ', '&nbsp;')|safe }}</code>
+              </h4>
+              <p class="iati-card-body">
               <table class="table table-striped">
                 {% for publisher in publishers %}
                 <tr>
@@ -72,6 +70,7 @@
                 </tr>
                 {% endfor %}
               </table>
+              </p>
             </div>
             {% endif %}
             {% endfor %}
@@ -79,19 +78,24 @@
           </div>
         </div>
       </div>
+      </div>
+      </div>
 
+    <div class="row">
       <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Other versions</h3>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading">
+            <h3 class="dashboard-panel-heading__title">Other versions</h3>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
           <p>Listing of publishers publishing a non-recognised version number.  Click on any publisher name for more information.</p>
-          <div class="row">
+          <div class="iati-card-gallery">
             {% for version, publishers in current_stats.inverted_publisher.versions.items() %}
             {% if version not in expected_versions %}
-            <div class="col-md-4">
+            <div class="iati-card">
+              <h4>
               <code>{{ version|replace(' ', '&nbsp;')|safe }}</code>
+              </h4>
               <table class="table table-striped">
                 {% for publisher in publishers %}
                 <tr>

--- a/dashboard/templates/xml.html
+++ b/dashboard/templates/xml.html
@@ -12,11 +12,12 @@
     <div class="row">
 
     <div class="col-md-6">
-    <div class="panel panel-default">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/inverted-file/invalidxml.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Files where XML is not well-formed</h3>
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/inverted-file/invalidxml.json" class="float-end dashboard-panel-heading__title">(J)</a>
+        <h2 class="float-start dashboard-panel-heading__title">Files where XML is not well-formed</h2>
     </div>
+    <div class="dashboard-panel-body">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -28,7 +29,7 @@
             {% for dataset, invalid in current_stats.inverted_file.invalidxml.items() %}
             {% if invalid %}
             <tr>
-                {% set publisher=func.dataset_to_publisher(package) %}
+                {% set publisher=func.dataset_to_publisher(dataset) %}
                 <td><a href="{% if publisher %}{{ url("dash-headlines-publisher-detail", args=[publisher]) }}{% endif %}">{{ publisher }}</a></td>
                 <td><a href="http://iatiregistry.org/dataset/{{ dataset }}">{{ dataset }}</a></td>
             </tr>
@@ -38,14 +39,16 @@
     </table>
     </div>
     </div>
+    </div>
 
     <div class="col-md-6">
-    <div class="panel panel-default">
-    <table class="table table-striped">
-    <div class="panel-heading">
-        <a href="{{ stats_url }}/current/inverted-file/nonstandardroots.json" style="float:right">(J)</a>
-        <h3 class="panel-title">Files with non-standard roots</h3>
+    <div class="dashboard-panel">
+    <div class="dashboard-panel-heading clearfix">
+        <a href="{{ stats_url }}/current/inverted-file/nonstandardroots.json" class="float-end dashboard-panel-heading__title">(J)</a>
+        <h2 class="float-start dashboard-panel-heading__title">Files with non-standard roots</h2>
     </div>
+    <div class="dashboard-panel-body">
+    <table class="table table-striped">
         <thead>
             <tr>
                 <th>Publisher</th>
@@ -56,7 +59,7 @@
             {% for dataset, nonstandard in current_stats.inverted_file.nonstandardroots.items() %}
             {% if nonstandard %}
             <tr>
-                {% set publisher=func.dataset_to_publisher(package) %}
+                {% set publisher=func.dataset_to_publisher(dataset) %}
                 <td><a href="{% if publisher %}{{ url("dash-headlines-publisher-detail", args=[publisher]) }}{% endif %}">{{ publisher }}</a></td>
                 <td><a href="http://iatiregistry.org/dataset/{{ dataset }}">{{ dataset }}</a></td>
             </tr>
@@ -64,6 +67,7 @@
             {% endfor %}
         </tbody>
     </table>
+    </div>
     </div>
     </div>
 


### PR DESCRIPTION
Most Dashboard pages are organised using the Bootstrap .panel that was dropped in Bootstrap 4.  To preserve the current look and feel a set of custom `.dashboard-panel-*` CSS classes has been created, including `.dashboard-panel`, `.dashboard-panel-heading`, and `.dashboard-panel-heading__title` which are similar in visual style to groups in the [Validator](https://validator.iatistandard.org) report page.  This PR adds these classes, removes unused classes, and modifies the templates to use the new panels.  Although `templates/_partials/boxes.html` uses `.panel ` this has not been changed in this PR.

Additional changes:
- Panel title layout was changed to use Boostrap utility classes `.float-start`, `.float-end` and `.clearfix`.
- As part of making this change some `<h*>` tags were moved around for consistency and to correct the header hierarchy.
- Some panels were removed if the page contained a single panel with no heading for consistency.
- Some panel grid layouts in the publisher detail and validator pages (associated with files failing validation) were replaced with a table.
- An issue with dataset names was uncovered where `dataset_name=dataset[:-4]` does not work as expected and this was fixed.
- Fixes a breadcrumb navigation error for the `registration_agencies.html` template.

Example (from timeliness pages) - before: 
![Screenshot_timeliness](https://github.com/user-attachments/assets/42fa6eaf-5aea-40fa-8564-990066ada443)

After:
![Screenshot_timeliness-new](https://github.com/user-attachments/assets/ffbfcc95-bb71-484d-b493-d37f74135477)
