### PR TITLE
Update boxes to use new .dashboard-panel-* classes

### DIFF
--- a/iati_dashboard/static/style.css
+++ b/iati_dashboard/static/style.css
@@ -10,16 +10,6 @@ em {
   font-size: 100px;
 }
 
-.title-number {
-  font-weight: bold;
-  float: left;
-  width: 20%;
-}
-
-.title-text {
-  float: left;
-}
-
 .break {
   word-break:break-all;
 }
@@ -101,6 +91,10 @@ a.popover-html:focus {
   color: #fff;
   margin-top: 0;
   margin-bottom: 0;
+}
+
+.dashboard-panel-heading__titlenum {
+  margin-right: 1rem;
 }
 
 .dashboard-panel-body {

--- a/iati_dashboard/templates/_partials/boxes.html
+++ b/iati_dashboard/templates/_partials/boxes.html
@@ -1,22 +1,55 @@
-{% macro box(title, number, image, json, legend, folderextra, description) %}
+{% macro box_h2(title, number, image, json, legend, folderextra, description) %}
       <div class="col-md-6">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              {% set title_id = title.replace(' ', '-').lower() %}
-              <span id="{{ title_id }}" class="title-number">{% if number is number %}{{ "{:,}".format(number) }}{% else %}{{ number }}{% endif %}</span>
-              <span class="title-text">{{ title }}</span>
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading clearfix">
+            <h2 class="dashboard-panel-heading__title float-start">
+              {% if number %}
+                {% set title_id = title.replace(' ', '-').lower() %}
+                <span id="{{ title_id }}" class="dashboard-panel-heading__titlenum" aria-hidden="true">{% if number is number %}{{ "{:,}".format(number) }}{% else %}{{ number }}{% endif %}</span>
+              {% endif %}
+              {{ title }}
+            </h2>
+            {% if json %}
+              {% if folderextra %}
+                <a href="{{ stats_url }}/gitaggregate{{ folderextra }}-dated/{{ json }}" class="float-end dashboard-panel-heading__title">(J)</a>
+              {% else %}
+                <a href="{{ stats_url }}/gitaggregate-dated/{{ json }}" class="float-end dashboard-panel-heading__title">(J)</a>
+              {% endif %}
+            {% endif %}
+          </div>
+          <div class="dashboard-panel-body">
+            {% if description %}
+              <p>{{ description|safe }}</p>
+            {% endif %}
+            <img src="{{ generated_url }}/{{ image }}" width="100%" />
+            {% if legend %}
+              <img src="{{ generated_url }}/{{ legend }}" width="100%" />
+            {% endif %}
+          </div>
+        </div>
+      </div>
+{% endmacro %}
+
+{% macro box_h3(title, number, image, json, legend, folderextra, description) %}
+      <div class="col-md-6">
+        <div class="dashboard-panel">
+          <div class="dashboard-panel-heading clearfix">
+            <h3 class="dashboard-panel-heading__title float-start">
+              {% if number %}
+                {% set title_id = title.replace(' ', '-').lower() %}
+                <span id="{{ title_id }}" class="dashboard-panel-heading__titlenum" aria-hidden="true">{% if number is number %}{{ "{:,}".format(number) }}{% else %}{{ number }}{% endif %}</span>
+              {% endif %}
+              {{ title }}
             </h3>
             {% if json %}
               {% if folderextra %}
-                <a href="{{ stats_url }}/gitaggregate{{ folderextra }}-dated/{{ json }}" style="float:right">(J)</a>
+                <a href="{{ stats_url }}/gitaggregate{{ folderextra }}-dated/{{ json }}" class="float-end dashboard-panel-heading__title">(J)</a>
               {% else %}
-                <a href="{{ stats_url }}/gitaggregate-dated/{{ json }}" style="float:right">(J)</a>
+                <a href="{{ stats_url }}/gitaggregate-dated/{{ json }}" class="float-end dashboard-panel-heading__title">(J)</a>
               {% endif %}
             {% endif %}
-            <div class="clearfix"></div>
           </div>
-          <div class="panel-body">
+          <div class="dashboard-panel-body">
             {% if description %}
               <p>{{ description|safe }}</p>
             {% endif %}

--- a/iati_dashboard/templates/activities.html
+++ b/iati_dashboard/templates/activities.html
@@ -2,13 +2,13 @@
 {% import '_partials/boxes.html' as boxes with context %} 
 {% block content %}
     <div class="row">
-      {{ boxes.box('Total activities', current_stats.aggregated.activities, 'img/aggregate/activities.png', 'activities.json',
+      {{ boxes.box_h2('Total activities', current_stats.aggregated.activities, 'img/aggregate/activities.png', 'activities.json',
         description='Total count of activities across all publishers, over time.
         Note: this includes activities with duplicate <code>iati-identifier</code>') }}
-      {{ boxes.box('Unique Activities', current_stats.aggregated.unique_identifiers, 'img/aggregate/unique_identifiers.png', 'unique_identifiers.json',
+      {{ boxes.box_h2('Unique Activities', current_stats.aggregated.unique_identifiers, 'img/aggregate/unique_identifiers.png', 'unique_identifiers.json',
         description='Total count of unique activities across all publishers, over time
         Note: this excludes counts of duplicate <code>iati-identifier</code>') }}
-      {{ boxes.box('Activities by publisher type', '', 'img/aggregate/activities_per_publisher_type.png', None, 'img/aggregate/activities_per_publisher_type_legend.png',
+      {{ boxes.box_h2('Activities by publisher type', '', 'img/aggregate/activities_per_publisher_type.png', None, 'img/aggregate/activities_per_publisher_type_legend.png',
         description='Count of all activities, aggregated by publisher type, over time.') }}
     </div>
 {% endblock %}

--- a/iati_dashboard/templates/download.html
+++ b/iati_dashboard/templates/download.html
@@ -2,7 +2,7 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Files that fail to download', current_stats.download_errors|length, 'img/aggregate/failed_downloads.png',
+      {{ boxes.box_h2('Files that fail to download', current_stats.download_errors|length, 'img/aggregate/failed_downloads.png',
         description='Count of files that fail to download, over time.') }}
     </div>
 

--- a/iati_dashboard/templates/files.html
+++ b/iati_dashboard/templates/files.html
@@ -2,13 +2,13 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Total activity files', current_stats.aggregated.activity_files, 'img/aggregate/activity_files.png', 'activity_files.json',
+      {{ boxes.box_h2('Total activity files', current_stats.aggregated.activity_files, 'img/aggregate/activity_files.png', 'activity_files.json',
         description='Count of total number of activity files over time.') }}
-      {{ boxes.box('Total organisation files', current_stats.aggregated.organisation_files, 'img/aggregate/organisation_files.png', 'organisation_files.json',
+      {{ boxes.box_h2('Total organisation files', current_stats.aggregated.organisation_files, 'img/aggregate/organisation_files.png', 'organisation_files.json',
         description='Count of total number of organisation files, over time.') }}
     </div>
     <div class="row">
-      {{ boxes.box('Total File Size', current_stats.aggregated.file_size|filesizeformat, 'img/aggregate/file_size.png', 'file_size.json') }}
+      {{ boxes.box_h2('Total File Size', current_stats.aggregated.file_size|filesizeformat, 'img/aggregate/file_size.png', 'file_size.json') }}
       <div class="col-md-6">
         <div class="dashboard-panel">
         <div class="dashboard-panel-heading clearfix">

--- a/iati_dashboard/templates/organisation.html
+++ b/iati_dashboard/templates/organisation.html
@@ -2,7 +2,7 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Publishers without an Organisation File', current_stats.aggregated.publisher_has_org_file.no, 'img/aggregate/publisher_has_org_file.png', 'publisher_has_org_file.json',
+      {{ boxes.box_h2('Publishers without an Organisation File', current_stats.aggregated.publisher_has_org_file.no, 'img/aggregate/publisher_has_org_file.png', 'publisher_has_org_file.json',
         description='Count of publishers without an organisation file, over time.') }}
       <div class="col-md-6">
         <div class="dashboard-panel">

--- a/iati_dashboard/templates/publisher.html
+++ b/iati_dashboard/templates/publisher.html
@@ -121,23 +121,23 @@ Publisher: {{ publisher_name[publisher] }} {{ super() }}
     </div>
     </div>
     </div>
-    {{ boxes.box(
+    {{ boxes.box_h3(
         'Activities', publisher_stats.activities, 'img/publishers/'+publisher+'_activities.png', publisher+'/activities.json', '', '-publisher') }} 
     </div>
 
     <div class="row">
-        {{ boxes.box('Activity Files', publisher_stats.activity_files, 'img/publishers/'+publisher+'_activity_files.png', publisher+'/activity_files.json', '', '-publisher') }}
-        {{ boxes.box('Organisation Files', publisher_stats.organisation_files, 'img/publishers/'+publisher+'_organisation_files.png', publisher+'/organisation_files.json', '', '-publisher') }}
+        {{ boxes.box_h3('Activity Files', publisher_stats.activity_files, 'img/publishers/'+publisher+'_activity_files.png', publisher+'/activity_files.json', '', '-publisher') }}
+        {{ boxes.box_h3('Organisation Files', publisher_stats.organisation_files, 'img/publishers/'+publisher+'_organisation_files.png', publisher+'/organisation_files.json', '', '-publisher') }}
     </div>
 
     <div class="row">
-        {{ boxes.box('Files per version', '', 'img/publishers/'+publisher+'_versions.png', publisher+'/versions.json', 'img/publishers/'+publisher+'_versions_legend.png', '-publisher') }}
-        {{ boxes.box('Total File Size', publisher_stats.file_size|filesizeformat, 'img/publishers/'+publisher+'_file_size.png', publisher+'/file_size.json', '', '-publisher') }}
+        {{ boxes.box_h3('Files per version', '', 'img/publishers/'+publisher+'_versions.png', publisher+'/versions.json', 'img/publishers/'+publisher+'_versions_legend.png', '-publisher') }}
+        {{ boxes.box_h3('Total File Size', publisher_stats.file_size|filesizeformat, 'img/publishers/'+publisher+'_file_size.png', publisher+'/file_size.json', '', '-publisher') }}
     </div>
 
     <div class="row">
-        {{ boxes.box('Files failing validation', publisher_stats.validation.get('fail',0), 'img/publishers/'+publisher+'_validation.png', publisher+'/validation.json', '', '-publisher') }}
-        {{ boxes.box('Files where XML is not well-formed', publisher_stats.invalidxml, 'img/publishers/'+publisher+'_invalidxml.png', publisher+'/invalidxml.json', '', '-publisher') }}
+        {{ boxes.box_h3('Files failing validation', publisher_stats.validation.get('fail',0), 'img/publishers/'+publisher+'_validation.png', publisher+'/validation.json', '', '-publisher') }}
+        {{ boxes.box_h3('Files where XML is not well-formed', publisher_stats.invalidxml, 'img/publishers/'+publisher+'_invalidxml.png', publisher+'/invalidxml.json', '', '-publisher') }}
     </div>
 
     <h2 id="h_dataquality">Data Quality</h2>

--- a/iati_dashboard/templates/publishers.html
+++ b/iati_dashboard/templates/publishers.html
@@ -2,9 +2,9 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Publishers', current_stats.aggregated.publishers, 'img/aggregate/publishers.png', 'publishers.json',
+      {{ boxes.box_h2('Publishers', current_stats.aggregated.publishers, 'img/aggregate/publishers.png', 'publishers.json',
         description='This graph shows the number of organisations publishing IATI data over time.') }}
-      {{ boxes.box('Publishers by type', '', 'img/aggregate/publisher_types.png', None, 'img/aggregate/publisher_types_legend.png',
+      {{ boxes.box_h2('Publishers by type', '', 'img/aggregate/publisher_types.png', None, 'img/aggregate/publisher_types_legend.png',
         description='This graph show the various types of organisations publishing IATI data.') }}
     </div>
 

--- a/iati_dashboard/templates/validation.html
+++ b/iati_dashboard/templates/validation.html
@@ -2,9 +2,9 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Invalid files', current_stats.aggregated.validation.fail, 'img/aggregate/validation.png', 'validation.json',
+      {{ boxes.box_h2('Invalid files', current_stats.aggregated.validation.fail, 'img/aggregate/validation.png', 'validation.json',
         description='Count of files that do not validate against the relevant schema, over time.') }}
-      {{ boxes.box('Publishers with invalid files', current_stats.aggregated.publishers_validation.fail, 'img/aggregate/publishers_validation.png', 'publishers_validation.json',
+      {{ boxes.box_h2('Publishers with invalid files', current_stats.aggregated.publishers_validation.fail, 'img/aggregate/publishers_validation.png', 'publishers_validation.json',
         description='Count of publishers that have at least one invalid file, over time') }}
     </div>
 

--- a/iati_dashboard/templates/versions.html
+++ b/iati_dashboard/templates/versions.html
@@ -2,13 +2,13 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box('Files per version (expected)', '', 'img/aggregate/versions_expected.png', 'versions.json', 'img/aggregate/versions_expected_legend.png', description='Count of files per IATI version, over time. Expected: these are actual versions of the IATI Standard.') }}
-      {{ boxes.box('Files per version (other)', '', 'img/aggregate/versions_other.png', 'versions.json', 'img/aggregate/versions_other_legend.png', description='Count of files per other versions, over time. These values do not actually exist as IATI versions.') }}
+      {{ boxes.box_h2('Files per version (expected)', '', 'img/aggregate/versions_expected.png', 'versions.json', 'img/aggregate/versions_expected_legend.png', description='Count of files per IATI version, over time. Expected: these are actual versions of the IATI Standard.') }}
+      {{ boxes.box_h2('Files per version (other)', '', 'img/aggregate/versions_other.png', 'versions.json', 'img/aggregate/versions_other_legend.png', description='Count of files per other versions, over time. These values do not actually exist as IATI versions.') }}
     </div>
     <div class="row">
-      {{ boxes.box('Publishers per version (expected)', '', 'img/aggregate/publishers_per_version_expected.png', 'publishers_per_version.json', 'img/aggregate/versions_expected_legend.png',
+      {{ boxes.box_h2('Publishers per version (expected)', '', 'img/aggregate/publishers_per_version_expected.png', 'publishers_per_version.json', 'img/aggregate/versions_expected_legend.png',
         description='Count of publishers per IATI version, over time. Note: If a publisher utilises two or more versions, they are counted for each.') }}
-      {{ boxes.box('Publishers per version (other)', '', 'img/aggregate/publishers_per_version_other.png', 'publishers_per_version.json', 'img/aggregate/versions_other_legend.png',
+      {{ boxes.box_h2('Publishers per version (other)', '', 'img/aggregate/publishers_per_version_other.png', 'publishers_per_version.json', 'img/aggregate/versions_other_legend.png',
         description='Count of publishers per other version, over time') }}
     </div>
 

--- a/iati_dashboard/templates/xml.html
+++ b/iati_dashboard/templates/xml.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <div class="row">
-      {{ boxes.box('Files where XML is not well-formed', current_stats.aggregated.invalidxml, 'img/aggregate/invalidxml.png', 'invalidxml.json',
+      {{ boxes.box_h2('Files where XML is not well-formed', current_stats.aggregated.invalidxml, 'img/aggregate/invalidxml.png', 'invalidxml.json',
         description='Count of files where the XML that is not well-formed, over time. Note: this is different from <a href="{}">validation against the schema</a>.'.format( url('dash-dataquality-validation'))) }}
-      {{ boxes.box('Files with non-standard roots', current_stats.aggregated.nonstandardroots, 'img/aggregate/nonstandardroots.png', 'nonstandardroots.json',
+      {{ boxes.box_h2('Files with non-standard roots', current_stats.aggregated.nonstandardroots, 'img/aggregate/nonstandardroots.png', 'nonstandardroots.json',
         description='Count of files with non-standard root, over time. Note: Files with non-standard roots are those where the root XML element is not <code>iati-activities</code> or <code>iati-organisation</code> as we would expect.</p>') }}
     </div>
 


### PR DESCRIPTION
The `boxes` tempate macro used Bootstrap panel and this commit changes `boxes` to use the new `.dashboard-panel-*` classes and `float`/`clearfix` Bootstrap layout for the box titles.  It also introduces two different versions of the box, for `<h2>` and `<h3>` header tags in the box title.