### PR TITLE
fix: correct URL listing error codes

### DIFF
--- a/iati_dashboard/templates/download.html
+++ b/iati_dashboard/templates/download.html
@@ -23,7 +23,7 @@
                 <th>Publisher</th>
                 <th>Registry Dataset</th>
                 <th style="max-width: 400px; overflow: clip;">URL</th>
-                <th><a href="https://everything.curl.dev/usingcurl/returns">Error Code</a></th>
+                <th><a href="https://everything.curl.dev/cmdline/exitcode.html">Error Code</a></th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
The download errors page will likely have different contents once we switch to the Bulk Data Service / Data Getter because the latter doesn't use `curl` codes, but in the mean time this fixes #687.