### PR TITLE
Realtime updates via the message queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ DEBUG=True python manage.py runserver
 
 The Dashboard will now be accessible from <http://localhost:8000/>.
 
+### 6. Run the real-time changes background processor
+
+```
+python manage.py run_realtime_update_processor
+```
+
+This requires setting three environment variables:
+`AZ_SERVICE_BUS_CONNECTION_STRING`, `AZ_SERVICE_BUS_TOPIC_NAME`, and
+`AZ_SERVICE_BUS_SUBSCRIPTION_NAME`. Get the value for the first from the Azure
+portal; the values for the other two are in the AsyncAPI specification stored
+here: https://github.com/IATI/iati-message-queue-service.
 
 ## Development
 

--- a/iati_dashboard/management/commands/run_realtime_update_processor.py
+++ b/iati_dashboard/management/commands/run_realtime_update_processor.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from ...registry_event_processor.registry_event_processor import RegistryEventProcessor
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        registry_processor = RegistryEventProcessor(args=settings.REGISTRY_UPDATE_PROCESSOR)
+        registry_processor.run()

--- a/iati_dashboard/registry_event_processor/registry_event_processor.py
+++ b/iati_dashboard/registry_event_processor/registry_event_processor.py
@@ -1,0 +1,173 @@
+import asyncio
+import json
+import traceback
+from datetime import datetime, timezone
+
+from asgiref.sync import sync_to_async
+from azure.servicebus.aio import ServiceBusClient
+from azure.servicebus.exceptions import ServiceBusConnectionError
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.utils import IntegrityError
+
+from ..models import Dataset, ReportingOrg
+
+
+class RegistryEventProcessor:
+
+    def __init__(self, args):
+        self._connection_str = args["AZ_SERVICE_BUS_CONNECTION_STRING"]
+        self._topic_name = args["AZ_SERVICE_BUS_TOPIC_NAME"]
+        self._subscription_name = args["AZ_SERVICE_BUS_SUBSCRIPTION_NAME"]
+        self._stop_event = asyncio.Event()
+        self._sb_client = None
+
+    def run(self):
+        try:
+            asyncio.run(self.service_loop())
+        except KeyboardInterrupt:
+            print("\n")
+            print("User pressed Ctrl-C. Exiting")
+
+    async def service_loop(self):
+        self._sb_client = ServiceBusClient.from_connection_string(conn_str=self._connection_str, logging_enable=True)
+        try:
+            while True:
+                await self.fetch_and_process_messages()
+                await asyncio.sleep(3)
+        finally:
+            await self._sb_client.close()
+
+    async def fetch_and_process_messages(self):
+        self.print_with_timestamp("Checking for messages")
+        try:
+            receiver = self._sb_client.get_subscription_receiver(
+                topic_name=self._topic_name, subscription_name=self._subscription_name, max_wait_time=1
+            )
+            async with receiver:
+                received_msgs = await receiver.receive_messages(max_wait_time=1, max_message_count=5)
+                for msg in received_msgs:
+                    await sync_to_async(self.dispatch_registry_event, thread_sensitive=True)(
+                        msg.application_properties[b"message_type"].decode("utf-8"), json.loads(str(msg))
+                    )
+                    await receiver.complete_message(msg)
+        except ServiceBusConnectionError as e:
+            self.print_with_timestamp(
+                f"RegistryEventProcessor.fetch_and_process_messages - Could not connect to Azure Service Bus, trying again in 15s - {e}"
+            )
+            await asyncio.sleep(15)
+        except Exception as e:
+            self.print_with_timestamp(f"RegistryEventProcessor.fetch_and_process_messages - Unexpected Error - {e}")
+            print(traceback.format_exc())
+
+    def dispatch_registry_event(self, message_type: str, message_payload: dict):
+        match message_type:
+            case "DATASET_CREATED":
+                self.process_registry_dataset_created(message_payload)
+            case "DATASET_UPDATED":
+                self.process_registry_dataset_updated(message_payload)
+            case "REPORTING_ORG_CREATED":
+                self.process_registry_reporting_org_created(message_payload)
+            case "REPORTING_ORG_UPDATED":
+                self.process_registry_reporting_org_updated(message_payload)
+            case "DATASET_DELETED" | "REPORTING_ORG_DELETED":
+                record_type = "dataset" if message_type == "DATASET_DELETED" else "reporting_org"
+                self.process_registry_record_deleted(record_type, message_payload)
+            case _:
+                print("Received unknown message type: ")
+                print(json.dumps(message_payload))
+
+    def process_registry_dataset_created(self, message_payload: dict):
+        try:
+            dataset = Dataset(
+                id=message_payload["dataset"]["id"],
+                short_name=message_payload["dataset"]["short_name"],
+                source_url=message_payload["dataset"]["url"],
+                stats_json={},
+                reporting_org=ReportingOrg.objects.get(id=message_payload["dataset"]["reporting_org_id"]),
+            )
+            dataset.save()
+            self.print_success("created", "dataset", message_payload["dataset"])
+        except ReportingOrg.DoesNotExist:
+            self.print_with_timestamp(
+                f"Failed to create dataset with ID {message_payload["dataset"]["id"]} because "
+                f"the parent reporting_org is not in the database"
+            )
+        except IntegrityError as e:
+            self.print_with_timestamp(
+                f"Failed to create dataset with ID {message_payload["dataset"]["id"]} because {str(e).replace('\n', ', ')}"
+            )
+
+    def process_registry_reporting_org_created(self, message_payload: dict):
+        try:
+            reporting_org = ReportingOrg(
+                id=message_payload["reporting_org"]["id"],
+                short_name=message_payload["reporting_org"]["short_name"],
+                human_readable_name=message_payload["reporting_org"]["human_readable_name"],
+                stats_json={"activity_files": 0, "organisation_files": 0},
+            )
+            reporting_org.save()
+            self.print_success("created", "reporting_org", message_payload["reporting_org"])
+        except IntegrityError as e:
+            self.print_with_timestamp(
+                f"Failed to create dataset with ID {message_payload["reporting_org"]["id"]} because {str(e).replace('\n', ', ')}"
+            )
+
+    def process_registry_dataset_updated(self, message_payload: dict):
+        try:
+            dataset = Dataset.objects.get(id=message_payload["dataset"]["id"])
+            dataset.short_name = message_payload["dataset"]["short_name"]
+            dataset.source_url = message_payload["dataset"]["url"]
+            dataset.reporting_org = ReportingOrg.objects.get(id=message_payload["dataset"]["reporting_org_id"])
+            dataset.save()
+            self.print_success("updated", "dataset", message_payload["dataset"])
+        except ReportingOrg.DoesNotExist:
+            self.print_with_timestamp(
+                f"Failed to update dataset with ID {message_payload["dataset"]["id"]} because "
+                f"the new parent reporting_org is not in the database"
+            )
+        except Dataset.DoesNotExist:
+            self.print_with_timestamp(
+                f"Failed to update dataset with ID {message_payload["dataset"]["id"]} because "
+                f"the dataset is not in the database"
+            )
+        except IntegrityError:
+            self.print_with_timestamp(
+                f"Failed to update dataset with ID {message_payload["dataset"]["id"]} because "
+                f"the new short_name is already in use"
+            )
+
+    def process_registry_reporting_org_updated(self, message_payload: dict):
+        try:
+            reporting_org = ReportingOrg.objects.get(id=message_payload["reporting_org"]["id"])
+            reporting_org.short_name = message_payload["reporting_org"]["short_name"]
+            reporting_org.human_readable_name = message_payload["reporting_org"]["human_readable_name"]
+            reporting_org.save()
+            self.print_success("updated", "reporting_org", message_payload["reporting_org"])
+        except ReportingOrg.DoesNotExist:
+            self.print_with_timestamp(
+                f"Failed to update reporting_org with ID {message_payload["reporting_org"]["id"]} because "
+                f"the reporting_org is not in the database"
+            )
+        except IntegrityError:
+            self.print_with_timestamp(
+                f"Failed to update reporting_org with ID {message_payload["reporting_org"]["id"]} because "
+                f"the new short_name is already in use"
+            )
+
+    def process_registry_record_deleted(self, record_type: str, message_payload: dict):
+        Model = Dataset if record_type == "dataset" else ReportingOrg
+        try:
+            record = Model.objects.get(id=message_payload[record_type]["id"])
+            record.delete()
+            self.print_success("deleted", record_type, message_payload[record_type])
+        except ObjectDoesNotExist:
+            self.print_with_timestamp(
+                f"Failed to delete {record_type} with ID {message_payload[record_type]["id"]} because "
+                f"the {record_type} is not in the database"
+            )
+
+    def print_success(self, change: str, record_type: str, record: dict):
+        self.print_with_timestamp(f"{change.capitalize()} {record_type} with ID {record["id"]}")
+
+    def print_with_timestamp(self, s: str):
+        print(f"{datetime.now(timezone.utc).isoformat()} - {s}")

--- a/iati_dashboard/settings.py
+++ b/iati_dashboard/settings.py
@@ -30,6 +30,9 @@ env = environ.Env(  # set default values and casting
     # Allow api features to only be enabled on a dev instance for now
     # This means we can keep it off live until we assess the performance implications
     ENABLE_API_ALPHA=(bool, False),
+    AZ_SERVICE_BUS_CONNECTION_STRING=(str, None),
+    AZ_SERVICE_BUS_TOPIC_NAME=(str, None),
+    AZ_SERVICE_BUS_SUBSCRIPTION_NAME=(str, None),
 )
 
 
@@ -189,4 +192,11 @@ STORAGES = {
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 50,
+}
+
+
+REGISTRY_UPDATE_PROCESSOR = {
+    "AZ_SERVICE_BUS_CONNECTION_STRING": env("AZ_SERVICE_BUS_CONNECTION_STRING"),
+    "AZ_SERVICE_BUS_TOPIC_NAME": env("AZ_SERVICE_BUS_TOPIC_NAME"),
+    "AZ_SERVICE_BUS_SUBSCRIPTION_NAME": env("AZ_SERVICE_BUS_SUBSCRIPTION_NAME"),
 }

--- a/requirements.in
+++ b/requirements.in
@@ -16,3 +16,4 @@ requests
 tqdm
 whitenoise
 sentry-sdk[django]
+azure-servicebus

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@
 #
 asgiref==3.8.1
     # via django
+azure-core==1.35.0
+    # via azure-servicebus
+azure-servicebus==7.14.2
+    # via -r requirements.in
 certifi==2025.6.15
     # via
     #   requests
@@ -39,6 +43,8 @@ gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
     # via requests
+isodate==0.7.2
+    # via azure-servicebus
 jinja2==3.1.6
     # via -r requirements.in
 kiwisolver==1.4.8
@@ -70,17 +76,24 @@ python-dateutil==2.9.0.post0
 pytz==2025.2
     # via -r requirements.in
 requests==2.32.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   azure-core
 sentry-sdk[django]==2.32.0
     # via -r requirements.in
 six==1.17.0
-    # via python-dateutil
+    # via
+    #   azure-core
+    #   python-dateutil
 sqlparse==0.5.3
     # via django
 tqdm==4.67.1
     # via -r requirements.in
 typing-extensions==4.14.0
-    # via psycopg
+    # via
+    #   azure-core
+    #   azure-servicebus
+    #   psycopg
 urllib3==2.5.0
     # via
     #   requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,12 @@ attrs==25.3.0
     # via
     #   outcome
     #   trio
+azure-core==1.35.0
+    # via
+    #   -r requirements.txt
+    #   azure-servicebus
+azure-servicebus==7.14.2
+    # via -r requirements.txt
 black==25.1.0
     # via -r requirements_dev.in
 certifi==2025.6.15
@@ -84,6 +90,10 @@ idna==3.10
     #   trio
 iniconfig==2.1.0
     # via pytest
+isodate==0.7.2
+    # via
+    #   -r requirements.txt
+    #   azure-servicebus
 isort==6.0.1
     # via -r requirements_dev.in
 jedi==0.19.2
@@ -191,6 +201,7 @@ pytz==2025.2
 requests==2.32.4
     # via
     #   -r requirements.txt
+    #   azure-core
     #   coveralls
     #   pytest-base-url
     #   pytest-selenium
@@ -201,6 +212,7 @@ sentry-sdk[django]==2.32.0
 six==1.17.0
     # via
     #   -r requirements.txt
+    #   azure-core
     #   python-dateutil
 sniffio==1.3.1
     # via trio
@@ -223,6 +235,8 @@ trio-websocket==0.12.2
 typing-extensions==4.14.0
     # via
     #   -r requirements.txt
+    #   azure-core
+    #   azure-servicebus
     #   psycopg
     #   selenium
 urllib3[socks]==2.5.0


### PR DESCRIPTION
This PR implements a Django management task which will run indefinitely checking for updates to dataset and reporting_org records received via the IATI Message Queue Service. It handles CREATED, UPDATED and DELETED messages for both datasets and repoting_orgs. 

Tasks outstanding on this: 

* Logging currently follows the main app of just printing to the console. 
* There are no tests as yet, as I wanted to discuss best approach to this.
* It currently creates a dummy `stats_json` field with just `activity_files` and `organisation_files` set to 0, so that the reporting_org API end point still works, but need to think about how best to create a more complete dummy stats_json object for reporting_orgs that are created via this method, given that we don't have the set of (even empty) stats files for them.