### PR TITLE
feat: add id fields to the output

### DIFF
--- a/iati_dashboard/api/serializers.py
+++ b/iati_dashboard/api/serializers.py
@@ -6,14 +6,15 @@ from ..models import Dataset, ReportingOrg
 class ReportingOrgSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = ReportingOrg
-        fields = ["short_name", "human_readable_name", "dataset_count"]
+        fields = ["id", "short_name", "human_readable_name", "dataset_count"]
 
 
 class DatasetSerializer(serializers.HyperlinkedModelSerializer):
+    reporting_org_id = serializers.PrimaryKeyRelatedField(many=False, read_only=True, source="reporting_org")
     reporting_org_short_name = serializers.SlugRelatedField(
         many=False, read_only=True, source="reporting_org", slug_field="short_name"
     )
 
     class Meta:
         model = Dataset
-        fields = ["short_name", "source_url", "reporting_org_short_name"]
+        fields = ["id", "short_name", "source_url", "reporting_org_id", "reporting_org_short_name"]


### PR DESCRIPTION
This PR adds the `id` fields to the API output, which we want to do now that the `id` fields used are the estate-wide UUIDs.