### PR TITLE
Catch error and return 404

### DIFF
--- a/iati_dashboard/ui/views.py
+++ b/iati_dashboard/ui/views.py
@@ -557,6 +557,8 @@ def exploringdata_publisher_codelist_detail(request, publisher_short_name=None, 
     if attribute.endswith("/text"):
         attribute += "()"
     values = publisher.stats_json.get("codelist_values_by_major_version", {}).get(major_version, {}).get(attribute)
+    if not values:
+        raise Http404("No data for that codelist")
 
     context = _make_context("publishers", include_large_dicts=False)
     context["publisher"] = publisher


### PR DESCRIPTION
(If not, the template crashes anyway and the user gets a 500)

https://github.com/IATI/IATI-Dashboard/issues/761