### PR TITLE
filters: Put filters in the UI behind a feature flag

### DIFF
--- a/.github/workflows/stats-and-dashboard-end-to-end.yml
+++ b/.github/workflows/stats-and-dashboard-end-to-end.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Run test script
       env:
         DATABASE_URL: "postgres://postgres:postgres@localhost:5432/test_database_name"
+        ENABLE_FILTERS_ALPHA: "True"
       run: |
         # -f bypasses checks before removing directories / dbs
         ./end_to_end_tests/run.sh -f

--- a/iati_dashboard/jinja2/publishers.html
+++ b/iati_dashboard/jinja2/publishers.html
@@ -17,11 +17,13 @@
     <a class="dashboard-panel-heading__title float-end" href="{{ generated_url }}/data/csv/publishers.csv">(This table as CSV)</a>
     </div>
     <div class="dashboard-panel-body">
+      {% if show_filters %}
         <form method="get">
             {{ filter.form.as_p() }}
             <button class="iati-button iati-button--submit">Submit</button>
         </form>
         <p>Reporting orgs in query: {{ filter.qs.count() }}</p>
+      {% endif %}
         <p>Click on the reporting org name for more details.</p>
         {% include '_partials/tablesorter_instructions.html' %}
     <table class="table table-striped">

--- a/iati_dashboard/settings.py
+++ b/iati_dashboard/settings.py
@@ -30,6 +30,7 @@ env = environ.Env(  # set default values and casting
     # Allow api features to only be enabled on a dev instance for now
     # This means we can keep it off live until we assess the performance implications
     ENABLE_API_ALPHA=(bool, False),
+    ENABLE_FILTERS_ALPHA=(bool, False),
     AZ_SERVICE_BUS_CONNECTION_STRING=(str, None),
     AZ_SERVICE_BUS_TOPIC_NAME=(str, None),
     AZ_SERVICE_BUS_SUBSCRIPTION_NAME=(str, None),
@@ -49,6 +50,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 
 ENABLE_API_ALPHA = env("ENABLE_API_ALPHA")
+ENABLE_FILTERS_ALPHA = env("ENABLE_FILTERS_ALPHA")
 
 
 if SENTRY_DSN:

--- a/iati_dashboard/ui/views.py
+++ b/iati_dashboard/ui/views.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 
 import dateutil.parser
+from django.conf import settings
 from django.db.models import Count, F
 from django.http import Http404, HttpResponse
 from django.template import loader
@@ -270,6 +271,7 @@ def faq(request):
 def headlines_publishers(request):
     context = _make_context("publishers", include_large_dicts=False)
     context["filter"] = filters.ReportingOrgFilter(request.GET, queryset=models.ReportingOrg.objects.all())
+    context["show_filters"] = settings.ENABLE_FILTERS_ALPHA
     template = loader.get_template("publishers.html")
     return HttpResponse(template.render(context, request))
 


### PR DESCRIPTION
(Leave filters in the API alone, because the API is behind its own feature flag).