### PR TITLE
feat(errors): Update download errors page to use bulk data service

### DIFF
--- a/end_to_end_tests/fixtures/iati-data/datasets-full.json
+++ b/end_to_end_tests/fixtures/iati-data/datasets-full.json
@@ -34,6 +34,28 @@
       "reporting_org_short_name": "test_ro_1",
       "source_url": "http://example.com/5",
       "licence_id": "cc-zero"
+    },
+    {
+      "id": "f59f76d4-f051-4e0f-8b8c-f75179f16268",
+      "short_name": "no_successful_downloads-dataset1",
+      "reporting_org_short_name": "no_successful_downloads",
+      "source_url": "http://example.com/6",
+      "licence_id": "cc-zero",
+      "most_recent_get_attempt": {
+        "datetime": "2025-11-19 16:45:11+00:00",
+        "error_details": {
+          "detailed_message": null,
+          "error_type": "http_non_200",
+          "http_headers": {},
+          "http_method": "GET",
+          "http_reason": "Not Found",
+          "http_status": 404,
+          "source_url": "http://example.com/6",
+          "summary_message": "Download of IATI XML failed with non-200 HTTP status"
+        },
+        "error_occurred": true,
+        "http_status": 404
+      }
     }
   ]
 }

--- a/end_to_end_tests/fixtures/iati-data/reporting-orgs.json
+++ b/end_to_end_tests/fixtures/iati-data/reporting-orgs.json
@@ -29,6 +29,12 @@
       "short_name": "test_ro_1",
       "human_readable_name": "Test RO 1",
       "organisation_type": "40"
+    },
+    {
+      "id": "7d4a43b3-2c5c-42ac-934a-5e0143146ff1",
+      "short_name": "no_successful_downloads",
+      "human_readable_name": "Test Organisation with no successful downloads",
+      "organisation_type": "40"
     }
   ]
 }

--- a/end_to_end_tests/tests.py
+++ b/end_to_end_tests/tests.py
@@ -14,12 +14,23 @@ def firefox_options(firefox_options):
     return firefox_options
 
 
-def test_home_page(selenium):
-    root_url = "http://localhost:8000"
+root_url = "http://localhost:8000"
 
+
+def test_home_page(selenium):
     selenium.get(root_url)
     assert "Dashboard Home" in selenium.find_element("tag name", "body").text
 
+
+def test_downloads_errors(selenium):
+    selenium.get(f"{root_url}/errors/download-errors/")
+    tr = selenium.find_element("tag name", "table").find_element("tag name", "tbody").find_element("tag name", "tr")
+    assert "no_successful_downloads-dataset1" in tr.text
+    assert "http_non_200" in tr.text
+    assert "404" in tr.text
+
+
+def test_errors(selenium):
     selenium.get(f"{root_url}/errors/xml-errors/")
     xml_errors_body = selenium.find_element("tag name", "body").text
     selenium.get(f"{root_url}/errors/validation/")
@@ -38,6 +49,9 @@ def test_home_page(selenium):
     assert "in_ao_2-activities" not in xml_errors_body
     assert "in_ao_2-activities" not in schema_validation_body
 
+
+def test_reporting_orgs(selenium):
+    selenium.get(root_url)
     selenium.find_element("link text", "Reporting Orgs").click()
     assert selenium.current_url.endswith("/publishers/")
 

--- a/iati_dashboard/jinja2/download.html
+++ b/iati_dashboard/jinja2/download.html
@@ -2,16 +2,10 @@
 {% import '_partials/boxes.html' as boxes with context %}
 {% block content %}
     <div class="row">
-      {{ boxes.box_h2('Files that fail to download', current_stats.download_errors|length, 'img/aggregate/failed_downloads.png',
-        description='Count of files that fail to download, over time.') }}
-    </div>
-
-    <div class="row">
       <div class="col-xs-12">
         <div class="dashboard-panel">
           <div class="dashboard-panel-heading clearfix">
             <h2 class="dashboard-panel-heading__title float-start">List of files that fail to download</h2>
-            <a class="dashboard-panel-heading__title light float-end" href="{{ url('dash-errors-download-json') }}">This table as JSON</a>
           </div>
           <div class="dashboard-panel-body">
         <p><a href="https://gist.github.com/codeforIATIbot/f117c9be138aa94c9762d57affc51a64/revisions">History of Download Errors</a></p>
@@ -21,19 +15,21 @@
               <table class="table iati-table__table">
                 <thead>
                   <tr>
-                    <th>Publisher</th>
-                    <th>Registry Dataset</th>
+                    <th>Reporting Org</th>
+                    <th>Dataset</th>
                     <th style="max-width: 400px; overflow: clip;">URL</th>
-                    <th><a href="https://everything.curl.dev/cmdline/exitcode.html">Error Code</a></th>
+                    <th>Error Type</th>
+                    <th>HTTP Status</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {% for code, publisher, dataset, err_url in current_stats.download_errors %}
+                  {% for dataset in datasets_with_errors %}
                   <tr>
-                    <td><a href="{{ url('dash-headlines-publisher-detail', args=[publisher]) }}">{{ publisher }}</a></td>
-                    <td><a href="http://iatiregistry.org/dataset/{{ dataset }}">{{ dataset }}</a></td>
-                    <td style="max-width: 400px; overflow: clip;"><a href="{{ err_url }}">{{ err_url|url_to_filename }}</a></td>
-                    <td>{{ code }}</td>
+                    <td><a href="{{ url('dash-headlines-publisher-detail', args=[dataset.reporting_org.short_name]) }}">{{ dataset.reporting_org.human_readable_name }}</a></td>
+                    <td>{{ dataset.short_name }}</td>
+                    <td style="max-width: 400px; overflow: clip;"><a href="{{ dataset.source_url }}">{{ dataset.source_url|url_to_filename }}</a></td>
+                    <td>{{ dataset.error_type }}</td>
+                    <td>{{ dataset.http_status }}</td>
                   </tr>
                   {% endfor %}
                 </tbody>

--- a/iati_dashboard/jinja2/xml.html
+++ b/iati_dashboard/jinja2/xml.html
@@ -4,9 +4,7 @@
 {% block content %}
     <div class="row">
       {{ boxes.box_h2('Files where XML is not well-formed', current_stats.aggregated.invalidxml, 'img/aggregate/invalidxml.png', 'invalidxml.json',
-        description='Count of files where the XML that is not well-formed, over time. Note: this is different from <a href="{}">validation against the schema</a>.'.format( url('dash-errors-validation'))) }}
-      {{ boxes.box_h2('Files with non-standard roots', current_stats.aggregated.nonstandardroots, 'img/aggregate/nonstandardroots.png', 'nonstandardroots.json',
-        description='Count of files with non-standard root, over time. Note: Files with non-standard roots are those where the root XML element is not <code class="iati-code">iati-activities</code> or <code class="iati-code">iati-organisation</code> as we would expect.') }}
+        description='Count of files where the XML that is not well-formed, over time. This is different from <a href="{}">validation against the schema</a>. Note this decreased substantially in November 2025, because many of these errors are now encountered by the Bulk Data Service download, so can be found in the <a href="{}">Download Errors</a> section.'.format(url('dash-errors-validation'), url('dash-errors-download'))) }}
     </div>
 
     <div class="row">
@@ -42,38 +40,5 @@
     </div>
     </div>
     </div>
-
-    <div class="col-md-6">
-    <div class="dashboard-panel">
-    <div class="dashboard-panel-heading clearfix">
-        <a href="{{ stats_url }}/current/inverted-file/nonstandardroots.json" class="dashboard-panel-heading__title light float-end">(J)</a>
-        <h2 class="float-start dashboard-panel-heading__title">Files with non-standard roots</h2>
-    </div>
-    <div class="dashboard-panel-body">
-      <div class="iati-table">
-        <table class="table iati-table__table">
-          <thead>
-              <tr>
-                  <th>Publisher</th>
-                  <th>Dataset</th>
-              </tr>
-          </thead>
-          <tbody>
-              {% for dataset, nonstandard in current_stats.inverted_file.nonstandardroots.items() %}
-              {% if nonstandard %}
-              <tr>
-                  {% set publisher=func.dataset_to_publisher(dataset) %}
-                  <td><a href="{% if publisher %}{{ url("dash-headlines-publisher-detail", args=[publisher]) }}{% endif %}">{{ publisher }}</a></td>
-                  <td><a href="http://iatiregistry.org/dataset/{{ dataset }}">{{ dataset }}</a></td>
-              </tr>
-              {% endif %}
-              {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    </div>
-    </div>
-
     </div>
 {% endblock %}

--- a/iati_dashboard/tests/test_page_speed.py
+++ b/iati_dashboard/tests/test_page_speed.py
@@ -13,7 +13,6 @@ EXAMPLE_PAGES = [
     "exploring-data/",
     "faq/",
     "errors/download-errors/",
-    "data/download_errors.json",
     "errors/xml-errors/",
     "errors/validation/",
     "errors/identifiers/",

--- a/iati_dashboard/ui/tests.py
+++ b/iati_dashboard/ui/tests.py
@@ -32,7 +32,6 @@ class BasicPageTests(TestCase):
         """Test the data quality pages"""
 
         self.assertEqual(self.client.get(reverse("dash-errors-download")).status_code, 200)
-        self.assertEqual(self.client.get(reverse("dash-errors-download-json")).status_code, 200)
         self.assertEqual(self.client.get(reverse("dash-errors-xml")).status_code, 200)
         self.assertEqual(self.client.get(reverse("dash-errors-validation")).status_code, 200)
         self.assertEqual(self.client.get(reverse("dash-identifiers")).status_code, 200)

--- a/iati_dashboard/ui/urls.py
+++ b/iati_dashboard/ui/urls.py
@@ -43,11 +43,6 @@ urlpatterns = (
         path("faq/", views.faq, name="dash-faq"),
         # Errors pages.
         path("errors/download-errors/", views.errors_download, name="dash-errors-download"),
-        path(
-            "data/download_errors.json",
-            views.errors_download_errorsjson,
-            name="dash-errors-download-json",
-        ),
         path("errors/xml-errors/", views.errors_xml, name="dash-errors-xml"),
         path("errors/validation/", views.errors_validation, name="dash-errors-validation"),
         path("errors/identifiers/", views.errors_identifiers, name="dash-identifiers"),

--- a/iati_dashboard/ui/views.py
+++ b/iati_dashboard/ui/views.py
@@ -385,12 +385,18 @@ def headlines_publisher_detail(request, publisher_short_name=None):
 #
 def errors_download(request):
     template = loader.get_template("download.html")
-    context = _make_context("download")
+    context = _make_context("download", include_large_dicts=False)
+    context["datasets_with_errors"] = (
+        models.Dataset.objects.exclude(metadata_json__most_recent_get_attempt__error_details__error_type=None)
+        .select_related("reporting_org")
+        .annotate(
+            error_type=F("metadata_json__most_recent_get_attempt__error_details__error_type"),
+            http_status=F("metadata_json__most_recent_get_attempt__error_details__http_status"),
+        )
+        .order_by("reporting_org__human_readable_name")
+        .defer("stats_json", "metadata_json")
+    )
     return HttpResponse(template.render(context, request))
-
-
-def errors_download_errorsjson(request):
-    return HttpResponse(json.dumps(current_stats["download_errors"], indent=2), content_type="application/json")
 
 
 def errors_xml(request):


### PR DESCRIPTION
This removes the json endpoint for download errors, instead people can look at the bulk data service json metadata file directly.

This also removes the non-standard roots section, because the bulk data service picks up all of these.