### PR TITLE
fix(jinja filters): Turn insecure http links into urls correctly

### DIFF
--- a/end_to_end_tests/tests.py
+++ b/end_to_end_tests/tests.py
@@ -88,11 +88,16 @@ def test_reporting_orgs(selenium):
     assert recipient_countries_cell.text == "1"
     href = recipient_countries_cell.find_element("tag name", "a").get_attribute("href")
     assert href.endswith("/publishers/in_ao_1/#p_countries")
+
     selenium.get(href)
+
     recipient_countries_panel = selenium.find_element("css selector", "#p_countries")
     assert "Recipient Countries" in recipient_countries_panel.text
     assert "AO" in recipient_countries_panel.text
     assert "Angola" in recipient_countries_panel.text
+
+    source_url_1 = selenium.find_element("link text", "Source Url")
+    assert source_url_1.get_attribute("href") == "http://example.com/1"
 
 
 def test_reporting_orgs_filter(selenium):

--- a/iati_dashboard/ui/jinja2.py
+++ b/iati_dashboard/ui/jinja2.py
@@ -36,7 +36,7 @@ def xpath_to_url(path):
 
 
 def linkurl(url, link_text=None):
-    if url.startswith("https://") or url.startswith("https://"):
+    if url.startswith("http://") or url.startswith("https://"):
         return format_html('<a href="{}" rel="noopener">{}</a>', url, link_text or url)
     else:
         return link_text or url


### PR DESCRIPTION
This was accidentally broken in https://github.com/IATI/IATI-Dashboard/commit/7dcbcc744223c7de21de8d4ccd5dbb31716e577f